### PR TITLE
Refactor slime adapter and make mounting optional

### DIFF
--- a/ThunderAgent/__main__.py
+++ b/ThunderAgent/__main__.py
@@ -17,6 +17,8 @@ def main() -> int:
                         help="Router mode: 'default' (pure proxy) or 'tr' (capacity scheduling)")
     parser.add_argument("--backend-type", default="vllm", choices=["vllm", "sglang"],
                         help="Backend type: 'vllm' or 'sglang'")
+    parser.add_argument("--enable-slime-adapter", action="store_true",
+                        help="Enable Slime-compatible adapter endpoints (/generate, /workers, etc.)")
     parser.add_argument("--profile", action="store_true", 
                         help="Enable profiling (track prefill/decode/tool_call times)")
     parser.add_argument("--profile-dir", default="/tmp/thunderagent_profiles", 
@@ -41,6 +43,7 @@ def main() -> int:
         backends=backends,
         router_mode=args.router,
         backend_type=args.backend_type,
+        enable_slime_adapter=args.enable_slime_adapter,
         profile_enabled=args.profile,
         profile_dir=args.profile_dir,
         metrics_enabled=args.metrics,
@@ -54,6 +57,9 @@ def main() -> int:
     print(f"🚀 Router mode: {args.router}")
     if args.profile:
         print(f"📊 Profiling enabled - CSV output: {args.profile_dir}/step_profiles.csv")
+
+    if args.enable_slime_adapter:
+        print("🧩 Slime adapter enabled")
     
     if args.metrics:
         print(f"📈 Metrics monitoring enabled - interval: {args.metrics_interval}s")

--- a/ThunderAgent/adapters/__init__.py
+++ b/ThunderAgent/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Adapter registration helpers."""
+
+from .slime import create_slime_adapter
+
+__all__ = ["create_slime_adapter"]

--- a/ThunderAgent/adapters/slime/__init__.py
+++ b/ThunderAgent/adapters/slime/__init__.py
@@ -1,0 +1,5 @@
+"""Slime adapter package."""
+
+from .router import create_slime_adapter
+
+__all__ = ["create_slime_adapter"]

--- a/ThunderAgent/adapters/slime/router.py
+++ b/ThunderAgent/adapters/slime/router.py
@@ -1,0 +1,154 @@
+"""Slime adapter router definitions."""
+
+import logging
+from typing import Any, Callable, Dict
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from ...scheduler import MultiBackendRouter
+from .utils import (
+    extract_sglang_usage,
+    extract_worker_url,
+    format_workers,
+    read_json,
+    resolve_worker_url,
+)
+
+
+def create_slime_adapter(
+    state_router: MultiBackendRouter,
+    program_id_getter: Callable[[Dict[str, Any]], str],
+    logger: logging.Logger,
+) -> APIRouter:
+    """Create Slime-compatible adapter router."""
+    adapter_router = APIRouter()
+
+    _register_generate_route(
+        adapter_router=adapter_router,
+        state_router=state_router,
+        program_id_getter=program_id_getter,
+        logger=logger,
+    )
+    _register_worker_routes(
+        adapter_router=adapter_router,
+        state_router=state_router,
+    )
+    return adapter_router
+
+
+# -------------------------------------------------------------------------
+# Route Registration
+# -------------------------------------------------------------------------
+
+def _register_generate_route(
+    *,
+    adapter_router: APIRouter,
+    state_router: MultiBackendRouter,
+    program_id_getter: Callable[[Dict[str, Any]], str],
+    logger: logging.Logger,
+) -> None:
+    """Register Slime-compatible /generate route."""
+
+    @adapter_router.post("/generate")
+    async def generate(request: Request):
+        """Handle Slime/SGLang-style generate requests with TR scheduling semantics."""
+        payload = await read_json(request)
+
+        if not state_router.backends:
+            raise HTTPException(status_code=503, detail="No workers available. Add workers via /add_worker first.")
+
+        program_id = program_id_getter(payload)
+        program_state = state_router.get_or_create_program(program_id)
+
+        if program_state.profile:
+            program_state.profile.on_request_arrive()
+
+        await state_router.update_program_before_request(program_id, program_state, payload)
+
+        if program_state.profile:
+            program_state.profile.on_request_start()
+
+        backend = state_router.get_backend_for_program(program_id)
+        try:
+            output = await state_router.proxy_json_post(backend, "/generate", payload)
+        except Exception as exc:
+            logger.exception("Failed to proxy /generate request to %s", backend.url)
+            raise HTTPException(status_code=502, detail=f"Backend generate request failed: {exc}") from exc
+
+        total_tokens, prompt_tokens, cached_tokens = extract_sglang_usage(output)
+        state_router.update_program_after_request(program_id, program_state, total_tokens, prompt_tokens)
+        if program_state.profile:
+            program_state.profile.on_request_end(prompt_tokens, cached_tokens)
+
+        return JSONResponse(output)
+
+
+def _register_worker_routes(
+    *,
+    adapter_router: APIRouter,
+    state_router: MultiBackendRouter,
+) -> None:
+    """Register worker management routes used by Slime/SGLang router clients."""
+
+    @adapter_router.post("/add_worker")
+    async def add_worker(request: Request):
+        """SGLang-router compatible endpoint to add worker."""
+        worker_url = await extract_worker_url(request)
+        added = await state_router.add_backend(worker_url)
+        return JSONResponse(
+            {"status": "success", "added": added, "worker_urls": state_router.list_backend_urls()}
+        )
+
+    @adapter_router.post("/remove_worker")
+    async def remove_worker(request: Request):
+        """SGLang-router compatible endpoint to remove worker."""
+        worker_url = await extract_worker_url(request)
+        try:
+            removed = await state_router.remove_backend(worker_url)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+        if not removed:
+            raise HTTPException(status_code=404, detail=f"Worker not found: {worker_url}")
+
+        return JSONResponse(
+            {"status": "success", "removed": True, "worker_urls": state_router.list_backend_urls()}
+        )
+
+    @adapter_router.get("/list_workers")
+    async def list_workers():
+        """SGLang-router compatible endpoint to list workers."""
+        return JSONResponse({"urls": state_router.list_backend_urls()})
+
+    @adapter_router.get("/workers")
+    async def workers():
+        """Newer router-compatible worker listing endpoint."""
+        return JSONResponse({"workers": format_workers(state_router.list_backend_urls())})
+
+    @adapter_router.post("/workers")
+    async def add_worker_v2(request: Request):
+        """Newer router-compatible worker add endpoint."""
+        worker_url = await extract_worker_url(request)
+        added = await state_router.add_backend(worker_url)
+        return JSONResponse(
+            {"status": "success", "added": added, "workers": format_workers(state_router.list_backend_urls())}
+        )
+
+    @adapter_router.delete("/workers/{worker_ref}")
+    async def remove_worker_v2(worker_ref: str):
+        """Newer router-compatible worker remove endpoint by id or URL."""
+        workers = format_workers(state_router.list_backend_urls())
+        worker_url = resolve_worker_url(worker_ref, workers)
+
+        try:
+            removed = await state_router.remove_backend(worker_url)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+        if not removed:
+            raise HTTPException(status_code=404, detail=f"Worker not found: {worker_url}")
+
+        return JSONResponse(
+            {"status": "success", "removed": True, "workers": format_workers(state_router.list_backend_urls())}
+        )

--- a/ThunderAgent/adapters/slime/utils.py
+++ b/ThunderAgent/adapters/slime/utils.py
@@ -1,0 +1,85 @@
+"""Utility helpers for Slime adapter routes."""
+
+from typing import Any, Dict, List
+from urllib.parse import unquote
+
+from fastapi import HTTPException, Request
+
+
+def to_int(value: Any, default: int = 0) -> int:
+    """Safely cast a value to int."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+async def read_json(request: Request) -> Dict[str, Any]:
+    """Read JSON object from request, returning 400 on invalid payload."""
+    try:
+        payload = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON") from exc
+
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="JSON body must be an object")
+    return payload
+
+
+async def read_json_silent(request: Request) -> Dict[str, Any]:
+    """Best-effort JSON read, returning empty object when payload is unavailable."""
+    try:
+        payload = await request.json()
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def extract_sglang_usage(output: Dict[str, Any]) -> tuple[int, int, int]:
+    """Extract (total_tokens, prompt_tokens, cached_tokens) from SGLang response."""
+    meta_info = output.get("meta_info", {})
+    if not isinstance(meta_info, dict):
+        meta_info = {}
+
+    prompt_tokens = to_int(meta_info.get("prompt_tokens"), default=0)
+    cached_tokens = to_int(meta_info.get("cached_tokens"), default=0)
+    completion_tokens = to_int(meta_info.get("completion_tokens"), default=0)
+    if completion_tokens <= 0:
+        output_token_logprobs = meta_info.get("output_token_logprobs")
+        if isinstance(output_token_logprobs, list):
+            completion_tokens = len(output_token_logprobs)
+
+    total_tokens = to_int(meta_info.get("total_tokens"), default=prompt_tokens + completion_tokens)
+    if total_tokens <= 0:
+        total_tokens = prompt_tokens + completion_tokens
+
+    return total_tokens, prompt_tokens, cached_tokens
+
+
+async def extract_worker_url(request: Request) -> str:
+    """Extract worker URL from query string or JSON body."""
+    worker_url = request.query_params.get("url") or request.query_params.get("worker_url")
+    if worker_url:
+        return worker_url.rstrip("/")
+
+    payload = await read_json_silent(request)
+    worker_url = payload.get("url") or payload.get("worker_url")
+    if worker_url:
+        return str(worker_url).rstrip("/")
+
+    raise HTTPException(status_code=400, detail="worker_url is required (query ?url=... or JSON body).")
+
+
+def format_workers(worker_urls: List[str]) -> List[Dict[str, Any]]:
+    """Convert backend URLs to router-compatible worker objects."""
+    return [{"id": idx, "url": url} for idx, url in enumerate(worker_urls)]
+
+
+def resolve_worker_url(worker_ref: str, workers: List[Dict[str, Any]]) -> str:
+    """Resolve worker reference from numeric id or URL path component."""
+    if worker_ref.isdigit():
+        worker_id = int(worker_ref)
+        if worker_id < 0 or worker_id >= len(workers):
+            raise HTTPException(status_code=404, detail=f"Worker id not found: {worker_id}")
+        return workers[worker_id]["url"]
+    return unquote(worker_ref).rstrip("/")

--- a/ThunderAgent/config.py
+++ b/ThunderAgent/config.py
@@ -14,6 +14,9 @@ class Config:
 
     # Backend type: "vllm" or "sglang"
     backend_type: str = "vllm"
+
+    # Adapter configuration
+    enable_slime_adapter: bool = False
     
     # Profile configuration
     profile_enabled: bool = False

--- a/ThunderAgent/scheduler/router.py
+++ b/ThunderAgent/scheduler/router.py
@@ -1019,9 +1019,9 @@ class MultiBackendRouter:
         url = f"{backend_url.rstrip('/')}{path}"
         return await forward_get_request(self.client, url)
 
-    async def proxy_generate(self, backend: BackendState, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """Proxy a SGLang /generate request to a specific backend."""
-        url = f"{backend.url}/generate"
+    async def proxy_json_post(self, backend: BackendState, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Proxy a JSON POST request to a specific backend path."""
+        url = f"{backend.url.rstrip('/')}/{path.lstrip('/')}"
         response = await self.client.post(url, json=payload)
         response.raise_for_status()
         return response.json()


### PR DESCRIPTION
Supersedes #16.

- Refactor slime adapter into modular structure under `adapters/slime`
- Decouple slime routes from `app.py`/`router.py` with optional adapter mounting
- Keep generic router proxy API (`proxy_json_post`) for adapter use
- Add CLI/config switch to enable slime adapter explicitly