### PR TITLE
Add 32b fully async swe agent training example in skyrl

### DIFF
--- a/examples/rl_training/SkyRL/.gitignore
+++ b/examples/rl_training/SkyRL/.gitignore
@@ -1,0 +1,18 @@
+# Credentials (use .example files as templates)
+api-keys.sh
+cluster-config.sh
+
+# Training artifacts
+training_data/
+slurm-*.out
+slurm-*.err
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+
+# Planning files (session-specific)
+task_plan.md
+findings.md
+progress.md

--- a/examples/rl_training/SkyRL/api-keys.sh.example
+++ b/examples/rl_training/SkyRL/api-keys.sh.example
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copy this file to api-keys.sh and fill in your credentials:
+#   cp api-keys.sh.example api-keys.sh
+#   chmod 600 api-keys.sh
+#
+# REQUIRED:
+export WANDB_API_KEY="<your_wandb_api_key>"
+
+# REQUIRED for model/dataset download:
+export HF_TOKEN="<your_huggingface_token>"
+
+# OPTIONAL: Docker Hub credentials for SWE-bench image pulls (rate limit: 200 pulls/6h free tier).
+# Multiple accounts allow parallel pulls. Leave empty if using Docker Hub Pro or pre-cached images.
+export DOCKER_HUB_USER_1=""
+export DOCKER_HUB_PAT_1=""
+# export DOCKER_HUB_USER_2=""
+# export DOCKER_HUB_PAT_2=""

--- a/examples/rl_training/SkyRL/cluster-config.sh.example
+++ b/examples/rl_training/SkyRL/cluster-config.sh.example
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copy this file to cluster-config.sh and customize for your SLURM cluster:
+#   cp cluster-config.sh.example cluster-config.sh
+#
+# These are optional overrides - defaults work for most clusters.
+
+# NCCL cross-node configuration (REQUIRED for multi-node Docker training):
+# Set to your cluster's inter-node network interface name.
+# Common values: ens7, eth0, ib0, enp1s0f0
+# Find yours with: ip route | grep default | awk '{print $5}'
+export NCCL_SOCKET_IFNAME="ens7"
+
+# Set to 1 if InfiniBand is not available inside Docker containers:
+export NCCL_IB_DISABLE=1
+
+# Docker image (default should work for most setups):
+export DOCKER_IMAGE="novaskyai/skyrl-train-ray-2.51.1-py3.12-cu12.8"
+
+# Paths (defaults inferred from script location):
+# export SKYRL_HOST_DIR="/path/to/SkyRL"
+# export THUNDERAGENT_HOST_DIR="/path/to/ThunderAgent"
+# export TRAINING_DATA_SYNC_DEST="/path/to/output"

--- a/examples/rl_training/SkyRL/docs/reproduce_32b_megatron.md
+++ b/examples/rl_training/SkyRL/docs/reproduce_32b_megatron.md
@@ -1,0 +1,181 @@
+# Reproducing 32B Qwen3 Fully Async GRPO Training on SWE-Gym
+
+## Overview
+
+This guide walks through reproducing 32B Qwen3 fully async GRPO training on SWE-Gym,
+comparing ThunderAgent **default** vs **TR** router modes.
+
+The experiment uses 6 nodes (48 GPUs allocated, 40 used) with Megatron-based training
+(TP=4, PP=4, CP=2, DP=1) and 4 vLLM TP=2 inference engines.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ NODE 0 (HEAD): Ray GCS + 128 SWE workers + Docker-in-Docker      │
+│   - ray start --num-gpus=0 (8 GPUs idle, allocated by SLURM)     │
+│   - ThunderAgent proxy (port 8001) + SkyRL entrypoint (8002)     │
+│                                                                  │
+│ NODE 1 (Inference): 4 vLLM engines × TP=2 (DP=4)         8 GPUs  │
+│                                                                  │
+│ NODES 2-5 (Training): Megatron TP=4 PP=4 CP=2 DP=1      32 GPUs  │
+│   - PP stages 0-3, one stage per node                            │
+└──────────────────────────────────────────────────────────────────┘
+Total: 48 GPUs allocated by SLURM, 40 used (8 idle on HEAD node)
+```
+
+**Request flow**:
+```
+SWE Worker → LiteLLM (port 8001) → ThunderAgent (port 8001)
+  → SkyRL /engines/{id}/... (port 8002) → vLLM engine (TP=2)
+```
+
+## Prerequisites
+
+- **6 nodes** with 8 GPUs each (tested on H100 80GB)
+- **Docker** available on all nodes with `sudo` access for daemon configuration
+- **SLURM** with multi-node allocation support (`--nodes=6`)
+- **~65 GB** disk per node for Qwen3-32B model weights
+- **~500 GB** disk on HEAD node for SWE-bench Docker images (2400+)
+- **WandB API key** (required for training metrics)
+- **HuggingFace token** (required for model/dataset download)
+
+## Quick Start
+
+### 1. Set up credentials
+
+```bash
+cd <THUNDERAGENT_ROOT>/examples/rl_training/SkyRL
+
+# Copy and fill in your credentials
+cp api-keys.sh.example api-keys.sh
+chmod 600 api-keys.sh
+# Edit api-keys.sh with your WANDB_API_KEY and HF_TOKEN
+```
+
+### 2. Customize cluster config (optional)
+
+```bash
+cp cluster-config.sh.example cluster-config.sh
+# Edit cluster-config.sh:
+#   - NCCL_SOCKET_IFNAME: your inter-node network interface (find with: ip route | grep default | awk '{print $5}')
+#   - NCCL_IB_DISABLE: set to 1 if InfiniBand is unavailable inside Docker
+```
+
+### 3. Customize SBATCH headers
+
+Edit `sbatch_32b_megatron_default.sh` and `sbatch_32b_megatron_tr.sh`:
+- `--partition`: your cluster's partition name
+- `--cpus-per-task`: number of CPUs per node
+- `--time`: wall time limit
+- Optional: `--account`, `--qos`, `--exclude`
+
+### 4. Submit both experiments
+
+```bash
+bash submit_32b_megatron_default_vs_tr.sh
+```
+
+Or submit individually:
+```bash
+sbatch --export=ALL sbatch_32b_megatron_default.sh
+sbatch --export=ALL sbatch_32b_megatron_tr.sh
+```
+
+## Configuration Reference
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| Model | Qwen/Qwen3-32B | 17 safetensor shards, ~65 GB |
+| Algorithm | GRPO | `trainer.algorithm.advantage_estimator=grpo` |
+| Strategy | Megatron | TP=4, PP=4, CP=2, DP=1 |
+| vLLM engines | 4 × TP=2 | `gpu_memory_utilization=0.85` |
+| train_batch_size | 128 | prompts per step |
+| n_samples | 4 | samples per prompt → 512 trajectories/step |
+| max_training_seq_len | 40960 | ~40K tokens max |
+| max_input_length | 40960 | matches training seq len |
+| max_turns | 20 | SWE agent turns per trajectory |
+| parallel workers | 128 | concurrent SWE environments |
+| gradient_checkpointing | true | required for 32B |
+| micro_batch_size | 1 | per-device |
+| gradient_accumulation | 4 | effective batch = 4 × DP(1) = 4 micro-batches |
+
+## Monitoring
+
+### WandB Metrics
+Key metrics to watch:
+- `policy_loss`: should decrease over steps
+- `pass_at_1`, `pass_at_4`: solve rates
+- `num_real_trajectories` / `num_dummy_trajectories`: dummy ratio should stay <2%
+- `staleness`: weight version lag between inference and training
+
+### SLURM Logs
+```bash
+# Check job status
+squeue -u "$USER" --format="%.10i %.20j %.8T %.10M %.20N"
+
+# Training progress
+grep "Started: 'step'" slurm-<JOBID>.err
+grep "Finished: 'generate'" slurm-<JOBID>.err
+
+# Infrastructure metrics
+tail -f slurm-<JOBID>.err
+```
+
+### Profiler Data
+Infrastructure metrics are collected every 5s by `external_profiler.py`:
+- Output: `/scratch/profiler_data/job_<JOBID>/`
+- Synced to: `training_data/job_<JOBID>_32b_megatron_<tag>/`
+
+## Known Issues & Workarounds
+
+### NCCL Cross-Node in Docker
+Multi-node NCCL requires correct network interface configuration:
+```bash
+# In cluster-config.sh:
+export NCCL_SOCKET_IFNAME="ens7"    # your inter-node interface
+export NCCL_IB_DISABLE=1            # if no InfiniBand in Docker
+```
+Without this, NCCL picks Docker's bridge interface (not routable cross-node) and hangs.
+
+### KV Cache Pressure
+With 4 vLLM engines at `gpu_memory_utilization=0.85`, KV cache runs at ~91.7% utilization.
+This is tight but stable. Reducing to 0.80 wastes inference throughput; increasing to 0.90
+risks OOM during weight loading.
+
+### Epoch Boundary Idle Time
+At dataset epoch boundaries, the buffer drains and training idles for ~17 minutes while
+new trajectories are generated. This is expected behavior for fully async training.
+
+### Docker Hub Rate Limits
+SWE-bench requires pulling 2400+ Docker images. Free-tier Docker Hub allows 200 pulls/6h.
+Options:
+1. Pre-cache images on your nodes
+2. Use Docker Hub Pro
+3. Configure multiple Docker Hub accounts in `api-keys.sh`
+
+### PP Stage 0 Memory
+Megatron PP stage 0 (embedding + first layers) runs hottest at ~78 GiB during `policy_train`
+(96% of 80 GiB H100). The chunked logprob computation (`chunk_size=4096`) in
+`megatron_model_wrapper.py` is critical — without it, computing logprobs over 40960-token
+sequences would OOM instantly.
+
+### TP=2/CP=4 vs TP=4/CP=2
+TP=2 with CP=4 causes OOM. TP=4 with CP=2 fits (~27-35 GiB/GPU). Always use TP=4, CP=2
+for 32B training.
+
+<!-- ## Experimental Baseline (att29)
+
+From 29 iterations of 32B Megatron fully async training:
+- **43 training steps** completed over 27.3 hours
+- **pass@1**: 2.03% average, **pass@4**: 4.84% average
+- **Dummy rate**: <2% (most steps had 0 dummies)
+- **Per-engine routing**: KV cache hit rate ~40%
+- **Training speed**: ~40 min/step average (including generation + training)
+- **OOM crash** at step 43 (PP stage 0 memory spike) — recoverable via checkpoint restart -->
+
+<!-- ### Expected Results
+- **pass@1**: ~2% avg, **pass@4**: ~5% avg
+- **Training speed**: ~40 min/step
+- **Dummy rate**: <2% (failed/timeout trajectories)
+- **Steps completed**: 43 in 27.3 hours -->

--- a/examples/rl_training/SkyRL/external_profiler.py
+++ b/examples/rl_training/SkyRL/external_profiler.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+External vLLM metrics profiler for SkyRL training.
+
+Collects metrics from two sources:
+1. vLLM engine stat logs from Ray worker log files (KV cache, preemptions, throughput)
+2. HTTP /metrics endpoint (in-flight requests per engine)
+
+Runs inside the Docker container via srun --overlap.
+
+Usage: python3 external_profiler.py [--output-dir /scratch/profiler_data] [--poll-interval 5]
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime
+
+# Pattern to match vLLM LoggingStatLogger output
+# "Engine 000: Avg prompt throughput: 12.3 tokens/s, Avg generation throughput: 45.6 tokens/s,
+#  Running: 5 reqs, Waiting: 0 reqs, [Preemptions: N,] GPU KV cache usage: 78.9%,
+#  Prefix cache hit rate: 12.3%"
+VLLM_STATS_PATTERN = re.compile(
+    r"Engine (\d+): "
+    r"Avg prompt throughput: ([\d.]+) tokens/s, "
+    r"Avg generation throughput: ([\d.]+) tokens/s, "
+    r"Running: (\d+) reqs, "
+    r"Waiting: (\d+) reqs"
+    r"(?:, Preemptions: (\d+))?"
+    r"(?:, GPU KV cache usage: ([\d.]+)%)?"
+    r"(?:, Prefix cache hit rate: ([\d.]+)%)?"
+)
+
+# Pattern for timestamps in Ray worker logs (vLLM uses loguru-style timestamps)
+TIMESTAMP_PATTERN = re.compile(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[.,]\d+)")
+
+
+def find_ray_log_dir():
+    """Find the Ray session log directory."""
+    candidates = [
+        "/tmp/ray/session_latest/logs/",
+        "/tmp/ray/logs/",
+    ]
+    for d in candidates:
+        if os.path.isdir(d):
+            return d
+    # Fallback: find any ray session
+    ray_dir = "/tmp/ray/"
+    if os.path.isdir(ray_dir):
+        for entry in sorted(os.listdir(ray_dir), reverse=True):
+            logs_path = os.path.join(ray_dir, entry, "logs")
+            if os.path.isdir(logs_path):
+                return logs_path
+    return None
+
+
+def scan_worker_logs(log_dir, last_positions=None):
+    """Scan Ray worker log files for vLLM stats lines."""
+    if last_positions is None:
+        last_positions = {}
+
+    results = []
+    # vLLM uses Python logging which goes to stderr in Ray
+    worker_files = sorted(glob.glob(os.path.join(log_dir, "worker-*.err")))
+    worker_files += sorted(glob.glob(os.path.join(log_dir, "worker-*.out")))
+
+    for filepath in worker_files:
+        try:
+            file_size = os.path.getsize(filepath)
+            last_pos = last_positions.get(filepath, 0)
+
+            if file_size <= last_pos:
+                continue
+
+            with open(filepath, "r", errors="ignore") as f:
+                f.seek(last_pos)
+                for line in f:
+                    match = VLLM_STATS_PATTERN.search(line)
+                    if match:
+                        # Try to extract timestamp from the log line
+                        ts_match = TIMESTAMP_PATTERN.search(line)
+                        log_ts = ts_match.group(1) if ts_match else None
+
+                        entry = {
+                            "timestamp": time.time(),
+                            "log_timestamp": log_ts,
+                            "source": "ray_log",
+                            "log_file": os.path.basename(filepath),
+                            "engine_id": int(match.group(1)),
+                            "prompt_throughput_tps": float(match.group(2)),
+                            "generation_throughput_tps": float(match.group(3)),
+                            "num_running_reqs": int(match.group(4)),
+                            "num_waiting_reqs": int(match.group(5)),
+                        }
+                        if match.group(6) is not None:
+                            entry["num_preemptions"] = int(match.group(6))
+                        if match.group(7) is not None:
+                            entry["kv_cache_usage_pct"] = float(match.group(7))
+                        if match.group(8) is not None:
+                            entry["prefix_cache_hit_rate_pct"] = float(match.group(8))
+                        results.append(entry)
+
+                last_positions[filepath] = f.tell()
+        except Exception as e:
+            pass  # Silently skip unreadable files
+
+    return results, last_positions
+
+
+def poll_http_metrics(url, timeout=5):
+    """Poll the SkyRL HTTP /metrics endpoint for in-flight request counts."""
+    try:
+        import requests
+
+        resp = requests.get(url, timeout=timeout)
+        if resp.status_code == 200:
+            data = resp.json()
+            data["source"] = "http_endpoint"
+            data["poll_time"] = time.time()
+            return data
+    except Exception as e:
+        return {"source": "http_endpoint", "error": str(e), "poll_time": time.time()}
+    return None
+
+
+def count_docker_containers():
+    """Count running Docker containers (if docker is available)."""
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["docker", "ps", "--format", "{{.Names}}", "--filter", "name=minisweagent"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            containers = [c for c in result.stdout.strip().split("\n") if c]
+            return len(containers)
+    except Exception:
+        pass
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="External vLLM metrics profiler for SkyRL")
+    parser.add_argument("--output-dir", default="/scratch/profiler_data", help="Output directory for metrics")
+    parser.add_argument("--poll-interval", type=int, default=5, help="Polling interval in seconds")
+    parser.add_argument("--http-url", default="http://127.0.0.1:8001/metrics", help="SkyRL HTTP metrics URL")
+    parser.add_argument("--docker-interval", type=int, default=30, help="Docker container count interval")
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    start_time = int(time.time())
+    output_file = os.path.join(args.output_dir, f"profiler_{start_time}.jsonl")
+
+    log_dir = find_ray_log_dir()
+    print(f"=== External vLLM Profiler ===", flush=True)
+    print(f"Start time: {datetime.now().isoformat()}", flush=True)
+    print(f"Ray log directory: {log_dir}", flush=True)
+    print(f"Output file: {output_file}", flush=True)
+    print(f"Poll interval: {args.poll_interval}s", flush=True)
+    print(f"HTTP endpoint: {args.http_url}", flush=True)
+
+    if log_dir:
+        worker_count = len(glob.glob(os.path.join(log_dir, "worker-*.err")))
+        print(f"Worker log files found: {worker_count}", flush=True)
+    else:
+        print("WARNING: No Ray log directory found!", flush=True)
+
+    last_positions = {}
+    total_log_entries = 0
+    total_http_entries = 0
+    cycle = 0
+    last_docker_check = 0
+
+    with open(output_file, "a") as out_f:
+        # Write header metadata
+        header = {
+            "type": "header",
+            "start_time": start_time,
+            "ray_log_dir": log_dir,
+            "http_url": args.http_url,
+            "poll_interval": args.poll_interval,
+        }
+        out_f.write(json.dumps(header) + "\n")
+        out_f.flush()
+
+        while True:
+            try:
+                now = time.time()
+
+                # 1. Scan Ray worker logs for vLLM engine metrics
+                if log_dir:
+                    log_results, last_positions = scan_worker_logs(log_dir, last_positions)
+                    for entry in log_results:
+                        out_f.write(json.dumps(entry) + "\n")
+                        total_log_entries += 1
+
+                    # Report new vLLM log entries
+                    if log_results:
+                        latest = log_results[-1]
+                        kv_str = f"KV={latest.get('kv_cache_usage_pct', '?')}%" if 'kv_cache_usage_pct' in latest else "KV=N/A"
+                        preempt_str = f"preempt={latest.get('num_preemptions', 0)}" if 'num_preemptions' in latest else ""
+                        print(
+                            f"[{datetime.now().strftime('%H:%M:%S')}] "
+                            f"vLLM engine {latest['engine_id']}: "
+                            f"{kv_str}, "
+                            f"running={latest['num_running_reqs']}, "
+                            f"waiting={latest['num_waiting_reqs']}, "
+                            f"gen_tps={latest['generation_throughput_tps']:.1f} "
+                            f"{preempt_str} "
+                            f"(+{len(log_results)} entries, total={total_log_entries})",
+                            flush=True,
+                        )
+
+                # 2. Poll HTTP /metrics endpoint
+                http_data = poll_http_metrics(args.http_url)
+                if http_data and "error" not in http_data:
+                    out_f.write(json.dumps(http_data) + "\n")
+                    total_http_entries += 1
+
+                    # Print compact per-engine KV cache summary to stderr
+                    # (visible in sbatch .err / terminal even when stdout is redirected)
+                    engines = http_data.get("engines", [])
+                    if engines:
+                        parts = []
+                        total_running = 0
+                        total_preempt = 0
+                        for e in engines:
+                            kv = e.get("kv_cache_usage_pct", -1)
+                            ru = e.get("num_running_reqs", 0)
+                            pr = e.get("num_cumulative_preemption", 0)
+                            total_running += ru
+                            total_preempt += pr
+                            parts.append(f"e{e.get('engine_id', '?')}:{kv:5.1f}%({ru}r)")
+                        print(
+                            f"[{datetime.now().strftime('%H:%M:%S')}] "
+                            f"running={total_running} preempt={total_preempt} | "
+                            f"{' '.join(parts)}",
+                            file=sys.stderr,
+                            flush=True,
+                        )
+
+                # 3. Periodically count Docker containers
+                if now - last_docker_check > args.docker_interval:
+                    container_count = count_docker_containers()
+                    if container_count is not None:
+                        docker_entry = {
+                            "source": "docker",
+                            "timestamp": now,
+                            "minisweagent_containers": container_count,
+                        }
+                        out_f.write(json.dumps(docker_entry) + "\n")
+                        if cycle % 12 == 0:  # Print every ~minute
+                            print(f"[{datetime.now().strftime('%H:%M:%S')}] Docker containers: {container_count}", flush=True)
+                    last_docker_check = now
+
+                out_f.flush()
+                cycle += 1
+
+                # Periodic summary
+                if cycle % 60 == 0:
+                    elapsed = time.time() - start_time
+                    print(
+                        f"[{datetime.now().strftime('%H:%M:%S')}] "
+                        f"Summary: {total_log_entries} vLLM log entries, "
+                        f"{total_http_entries} HTTP polls, "
+                        f"elapsed={elapsed/60:.1f}min",
+                        flush=True,
+                    )
+
+                time.sleep(args.poll_interval)
+
+            except KeyboardInterrupt:
+                print(f"\nStopping profiler. Total: {total_log_entries} log entries, {total_http_entries} HTTP polls", flush=True)
+                break
+            except Exception as e:
+                print(f"Error in profiler loop: {e}", file=sys.stderr, flush=True)
+                time.sleep(args.poll_interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rl_training/SkyRL/launch_training_32b_megatron.sh
+++ b/examples/rl_training/SkyRL/launch_training_32b_megatron.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# launch_training_32b_megatron.sh - Runs inside the Docker container on the HEAD node
+# Starts ThunderAgent proxy + external profiler as background processes, then runs 32B Megatron fully async training
+# Usage: docker exec skyrl-head bash /scratch/SkyRL/launch_training_32b_megatron.sh [extra_hydra_overrides...]
+#
+# Environment variables:
+#   THUNDERAGENT_ROUTER  - "default" (pure proxy) or "tr" (capacity scheduling). Default: "default"
+#   ACTING_TOKEN_WEIGHT  - Token weight for TR router. Default: 1.0
+#   HEAD_NODE            - Hostname of the head node (for OPENAI_BASE_URL). Default: $(hostname)
+#   SLURM_JOB_ID        - SLURM job ID (for per-job profiler dirs)
+#   NUM_INFERENCE_ENGINES - Number of vLLM engines (for per-engine routing). Default: 4
+#
+# Architecture (6-node, per-engine routing):
+#   LiteLLM (port 8001) → ThunderAgent (port 8001) → SkyRL /engines/{id}/... (port 8002) → N vLLM engines (TP=2)
+
+set -e
+
+ROUTER_MODE="${THUNDERAGENT_ROUTER:-default}"
+HEAD_NODE="${HEAD_NODE:-$(hostname)}"
+echo "=== ThunderAgent router mode: $ROUTER_MODE ==="
+echo "=== HEAD_NODE: $HEAD_NODE ==="
+
+# Source environment
+source /workspace/SkyRL/api-keys.sh
+source /workspace/SkyRL/env_vars.sh
+export HYDRA_FULL_ERROR=1
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+export HEAD_NODE
+# Reduce Ray GCS task event overhead (defense-in-depth; must be set before ray start
+# on each node to affect workers — already in sbatch script's docker -e flags)
+export RAY_task_events_report_worker_events=false
+# H100 arch list — needed for megatron-core import on CPU-only HEAD node
+export TORCH_CUDA_ARCH_LIST="9.0+PTX"
+# UV cache: inherit from container env (HEAD uses /uv_cache_ram tmpfs, workers use /scratch/uv_cache_v2)
+export UV_CACHE_DIR="${UV_CACHE_DIR:-/scratch/uv_cache_v2}"
+mkdir -p "$UV_CACHE_DIR" 2>/dev/null
+
+echo "=== Environment configured ==="
+
+# Install ThunderAgent if not already installed
+if ! python3 -c "import ThunderAgent" 2>/dev/null; then
+    echo "=== Installing ThunderAgent ==="
+    pip install -e /scratch/ThunderAgent-wl 2>&1 | tail -5
+fi
+
+# Per-job profiler directories (avoid data contamination when nodes are reused)
+PROFILER_DIR="/scratch/profiler_data/job_${SLURM_JOB_ID:-unknown}"
+THUNDER_PROFILE_DIR="/scratch/thunderagent_profiles/job_${SLURM_JOB_ID:-unknown}"
+
+# Launch external profiler as background process
+mkdir -p "$PROFILER_DIR"
+cd /scratch/SkyRL
+nohup python3 external_profiler.py \
+  --output-dir "$PROFILER_DIR" \
+  --poll-interval 5 \
+  --http-url http://127.0.0.1:8002/metrics \
+  --docker-interval 30 \
+  > "$PROFILER_DIR/profiler.log" 2>&1 &
+PROFILER_PID=$!
+echo "=== External profiler started (PID=$PROFILER_PID), dir=$PROFILER_DIR ==="
+
+NUM_ENGINES="${NUM_INFERENCE_ENGINES:-4}"
+TRAIN_LOG="/tmp/training_inner_$$.log"
+
+# Launch training in background first (SkyRL HTTP endpoint starts on port 8002)
+# The entrypoint is a Ray task that may run on ANY node in the cluster.
+cd /scratch/SkyRL/skyrl-train
+echo "=== Starting 32B Megatron fully async training with args: $@ ==="
+bash examples/mini_swe_agent/run_mini_swe_32B_megatron_fully_async.sh "$@" > "$TRAIN_LOG" 2>&1 &
+TRAIN_PID=$!
+echo "=== Training launched in background (PID=$TRAIN_PID) ==="
+
+# Tail training log to stdout in background so it appears in the outer log
+tail -f "$TRAIN_LOG" --pid=$TRAIN_PID &
+TAIL_PID=$!
+
+# Detect the entrypoint IP by watching for HTTP endpoint startup message.
+# The Ray task that hosts port 8002 can be on any node (not necessarily HEAD).
+echo "=== Waiting for HTTP endpoint to start (detecting entrypoint IP)... ==="
+ENTRYPOINT_IP=""
+for i in $(seq 1 600); do
+  if [ -f "$TRAIN_LOG" ]; then
+    # Look for the entrypoint IP from the Ray task prefix: (skyrl_entrypoint pid=NNN, ip=X.X.X.X)
+    # Strip ANSI color codes first (Ray logs contain [36m etc.)
+    ENTRYPOINT_IP=$(sed 's/\x1b\[[0-9;]*m//g' "$TRAIN_LOG" 2>/dev/null | grep -oP 'skyrl_entrypoint pid=\d+, ip=\K[0-9.]+' | head -1)
+    if [ -n "$ENTRYPOINT_IP" ]; then
+      # Verify the HTTP endpoint is actually ready
+      if curl -sf "http://${ENTRYPOINT_IP}:8002/v1/models" > /dev/null 2>&1; then
+        echo "=== Entrypoint detected at ${ENTRYPOINT_IP}:8002 (after ${i}s) ==="
+        break
+      fi
+    fi
+  fi
+  sleep 1
+done
+
+if [ -z "$ENTRYPOINT_IP" ]; then
+  echo "WARNING: Could not detect entrypoint IP after 600s, falling back to 127.0.0.1"
+  ENTRYPOINT_IP="127.0.0.1"
+fi
+
+# Build per-engine backend URLs pointing to the actual entrypoint node.
+BACKENDS=""
+for i in $(seq 0 $((NUM_ENGINES - 1))); do
+  [ -n "$BACKENDS" ] && BACKENDS="${BACKENDS},"
+  BACKENDS="${BACKENDS}http://${ENTRYPOINT_IP}:8002/engines/${i}"
+done
+echo "=== ThunderAgent backends ($NUM_ENGINES engines): $BACKENDS ==="
+
+# Start ThunderAgent on port 8001 (where LiteLLM connects via OPENAI_BASE_URL)
+mkdir -p "$THUNDER_PROFILE_DIR"
+echo "=== ThunderAgent: starting with --router $ROUTER_MODE, backends on $ENTRYPOINT_IP ==="
+python3 -m ThunderAgent \
+  --host 0.0.0.0 \
+  --port 8001 \
+  --backends "$BACKENDS" \
+  --router "$ROUTER_MODE" \
+  --backend-type skyrl \
+  --profile \
+  --profile-dir "$THUNDER_PROFILE_DIR" \
+  --metrics \
+  --metrics-interval 5.0 \
+  --scheduler-interval 5.0 \
+  --acting-token-weight ${ACTING_TOKEN_WEIGHT:-1.0} \
+  --log-level info &
+THUNDERAGENT_PID=$!
+echo "=== ThunderAgent started (PID=$THUNDERAGENT_PID) on port 8001 ==="
+
+# Update external profiler to poll the entrypoint's metrics endpoint
+kill $PROFILER_PID 2>/dev/null || true
+cd /scratch/SkyRL
+nohup python3 external_profiler.py \
+  --output-dir "$PROFILER_DIR" \
+  --poll-interval 5 \
+  --http-url "http://${ENTRYPOINT_IP}:8002/metrics" \
+  --docker-interval 30 \
+  > "$PROFILER_DIR/profiler.log" 2>&1 &
+PROFILER_PID=$!
+echo "=== External profiler restarted with entrypoint IP $ENTRYPOINT_IP (PID=$PROFILER_PID) ==="
+
+# Wait for training to finish
+wait $TRAIN_PID
+TRAIN_EXIT=$?
+
+# Stop ThunderAgent and profiler when training finishes
+kill $THUNDERAGENT_PID 2>/dev/null || true
+echo "=== ThunderAgent stopped ==="
+kill $PROFILER_PID 2>/dev/null || true
+echo "=== Profiler stopped ==="
+kill $TAIL_PID 2>/dev/null || true
+
+exit $TRAIN_EXIT

--- a/examples/rl_training/SkyRL/sbatch_32b_megatron_default.sh
+++ b/examples/rl_training/SkyRL/sbatch_32b_megatron_default.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --job-name=32b-rdef
+#SBATCH --partition=batch
+#SBATCH --nodes=6
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --cpus-per-task=176
+#SBATCH --mem=0
+#SBATCH --time=96:00:00
+#SBATCH --output=slurm-%j.out
+#SBATCH --error=slurm-%j.err
+
+# 32B Megatron reproducibility job: ThunderAgent router=default.
+# You may need to edit SBATCH headers (partition/account/time/cpus) for your cluster.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export REPRO_ROUTER_MODE="default"
+export REPRO_ROUTER_TAG="default"
+unset REPRO_ACTING_TOKEN_WEIGHT || true
+
+bash "$SCRIPT_DIR/scripts/repro/run_32b_megatron_repro_job.sh"

--- a/examples/rl_training/SkyRL/sbatch_32b_megatron_tr.sh
+++ b/examples/rl_training/SkyRL/sbatch_32b_megatron_tr.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --job-name=32b-rtr
+#SBATCH --partition=batch
+#SBATCH --nodes=6
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --cpus-per-task=176
+#SBATCH --mem=0
+#SBATCH --time=96:00:00
+#SBATCH --output=slurm-%j.out
+#SBATCH --error=slurm-%j.err
+
+# 32B Megatron reproducibility job: ThunderAgent router=tr with acting_token_weight=1.0.
+# You may need to edit SBATCH headers (partition/account/time/cpus) for your cluster.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export REPRO_ROUTER_MODE="tr"
+export REPRO_ROUTER_TAG="tr_atw10"
+export REPRO_ACTING_TOKEN_WEIGHT="1.0"
+
+bash "$SCRIPT_DIR/scripts/repro/run_32b_megatron_repro_job.sh"

--- a/examples/rl_training/SkyRL/scripts/repro/run_32b_megatron_repro_job.sh
+++ b/examples/rl_training/SkyRL/scripts/repro/run_32b_megatron_repro_job.sh
@@ -1,0 +1,390 @@
+#!/bin/bash
+# Common launcher for 32B Megatron fully async SkyRL + ThunderAgent reproducibility jobs.
+# Expected to be invoked by sbatch scripts with:
+#   REPRO_ROUTER_MODE=default|tr
+#   REPRO_ROUTER_TAG=default|tr_atw10
+# Optional:
+#   REPRO_ACTING_TOKEN_WEIGHT=1.0
+#   SKYRL_HOST_DIR=/path/to/SkyRL
+#   THUNDERAGENT_HOST_DIR=/path/to/ThunderAgent-wl
+#   TRAINING_DATA_SYNC_DEST=/path/to/output/training_data
+#   DOCKER_IMAGE=novaskyai/skyrl-train-ray-2.51.1-py3.12-cu12.8
+#
+# Architecture (6-node layout):
+#   Node 0 (HEAD):     Ray GCS + 128 SWE workers + Docker-in-Docker (--num-gpus=0, 8 GPUs idle)
+#   Node 1 (Inference): 4 vLLM TP=2 engines (8 GPUs)
+#   Node 2-5 (Training): Megatron TP=4 PP=4 CP=2 (32 GPUs)
+#   Total: 48 GPUs allocated by SLURM, 40 used
+
+set -euo pipefail
+
+# --- Validate required env vars ---
+if [ -z "${REPRO_ROUTER_MODE:-}" ]; then
+  echo "ERROR: REPRO_ROUTER_MODE is required (default or tr)."
+  exit 1
+fi
+
+if [ -z "${REPRO_ROUTER_TAG:-}" ]; then
+  echo "ERROR: REPRO_ROUTER_TAG is required (for run_name and output paths)."
+  exit 1
+fi
+
+# --- Resolve paths ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKYRL_DEFAULT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKYRL_HOST_DIR="${SKYRL_HOST_DIR:-$SKYRL_DEFAULT_DIR}"
+
+# Source user's cluster config if present
+[ -f "$SKYRL_HOST_DIR/cluster-config.sh" ] && source "$SKYRL_HOST_DIR/cluster-config.sh"
+
+# Recompute dependent defaults after cluster-config overrides.
+# This avoids stale THUNDERAGENT_HOST_DIR when cluster-config changes SKYRL_HOST_DIR.
+SKYRL_HOST_DIR="${SKYRL_HOST_DIR:-$SKYRL_DEFAULT_DIR}"
+THUNDERAGENT_DEFAULT_DIR="$(cd "$SKYRL_HOST_DIR/../../.." 2>/dev/null && pwd || true)"
+THUNDERAGENT_HOST_DIR="${THUNDERAGENT_HOST_DIR:-$THUNDERAGENT_DEFAULT_DIR}"
+
+TRAINING_DATA_SYNC_DEST="${TRAINING_DATA_SYNC_DEST:-$SKYRL_HOST_DIR/training_data}"
+DOCKER_IMAGE="${DOCKER_IMAGE:-novaskyai/skyrl-train-ray-2.51.1-py3.12-cu12.8}"
+
+# NCCL cross-node config (critical for multi-node Docker training)
+NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-ens7}"
+NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-1}"
+
+# --- Validate ---
+if [ ! -f "$SKYRL_HOST_DIR/launch_training_32b_megatron.sh" ]; then
+  echo "ERROR: launch script not found at $SKYRL_HOST_DIR/launch_training_32b_megatron.sh"
+  echo "Set SKYRL_HOST_DIR to your SkyRL repo path."
+  exit 1
+fi
+
+if [ ! -f "$SKYRL_HOST_DIR/api-keys.sh" ]; then
+  echo "ERROR: missing $SKYRL_HOST_DIR/api-keys.sh"
+  echo "Create api-keys.sh with your WANDB_API_KEY and HF_TOKEN."
+  echo "See api-keys.sh.example for the template."
+  exit 1
+fi
+
+if [ ! -d "$THUNDERAGENT_HOST_DIR" ]; then
+  echo "ERROR: THUNDERAGENT_HOST_DIR does not exist: $THUNDERAGENT_HOST_DIR"
+  echo "Set THUNDERAGENT_HOST_DIR to your ThunderAgent repo path."
+  exit 1
+fi
+
+# --- Node assignment ---
+NODELIST=($(scontrol show hostnames $SLURM_JOB_NODELIST))
+if [ ${#NODELIST[@]} -lt 6 ]; then
+  echo "ERROR: Need 6 nodes, got ${#NODELIST[@]}. Use --nodes=6 in your sbatch script."
+  exit 1
+fi
+
+HEAD_NODE=${NODELIST[0]}       # Ray GCS + Docker-in-Docker (--num-gpus=0, 8 GPUs idle)
+INFERENCE_NODE=${NODELIST[1]}  # vLLM engines (8 GPUs)
+TRAINING_NODE_0=${NODELIST[2]} # Megatron PP stage 0 (8 GPUs)
+TRAINING_NODE_1=${NODELIST[3]} # Megatron PP stage 1 (8 GPUs)
+TRAINING_NODE_2=${NODELIST[4]} # Megatron PP stage 2 (8 GPUs)
+TRAINING_NODE_3=${NODELIST[5]} # Megatron PP stage 3 (8 GPUs)
+
+SCRATCH_DIR="/scratch/$USER"
+DOCKER_ROOT="/scratch/$USER/docker"
+ROUTER_MODE="$REPRO_ROUTER_MODE"
+ROUTER_TAG="$REPRO_ROUTER_TAG"
+ACTING_TOKEN_WEIGHT="${REPRO_ACTING_TOKEN_WEIGHT:-}"
+SLURM_JOB_ID_SAFE="${SLURM_JOB_ID:-manual}"
+
+echo "=== Job $SLURM_JOB_ID_SAFE: 32B Megatron (6-node layout), router=$ROUTER_MODE ==="
+echo "=== HEAD_NODE=$HEAD_NODE (rollout Docker, 0 GPUs registered) ==="
+echo "=== INFERENCE_NODE=$INFERENCE_NODE (vLLM, 8 GPUs) ==="
+echo "=== TRAINING_NODE_0=$TRAINING_NODE_0 (PP stage 0, 8 GPUs) ==="
+echo "=== TRAINING_NODE_1=$TRAINING_NODE_1 (PP stage 1, 8 GPUs) ==="
+echo "=== TRAINING_NODE_2=$TRAINING_NODE_2 (PP stage 2, 8 GPUs) ==="
+echo "=== TRAINING_NODE_3=$TRAINING_NODE_3 (PP stage 3, 8 GPUs) ==="
+echo "=== SkyRL host dir: $SKYRL_HOST_DIR ==="
+echo "=== ThunderAgent host dir: $THUNDERAGENT_HOST_DIR ==="
+echo "=== Training data sync dest: $TRAINING_DATA_SYNC_DEST ==="
+echo "=== Docker image: $DOCKER_IMAGE ==="
+echo "=== NCCL_SOCKET_IFNAME=$NCCL_SOCKET_IFNAME, NCCL_IB_DISABLE=$NCCL_IB_DISABLE ==="
+if [ -n "$ACTING_TOKEN_WEIGHT" ]; then
+  echo "=== acting_token_weight=$ACTING_TOKEN_WEIGHT ==="
+fi
+echo "=== $(date) ==="
+
+# srun helper: run on a specific node
+run_on() {
+    local NODE=$1; shift
+    srun --overlap --nodes=1 --ntasks=1 --gpus=0 --nodelist=$NODE "$@"
+}
+
+# --- Step 0: GPU cleanliness check ---
+echo "=== Checking GPU memory on GPU nodes ==="
+for NODE in $INFERENCE_NODE $TRAINING_NODE_0 $TRAINING_NODE_1 $TRAINING_NODE_2 $TRAINING_NODE_3; do
+    run_on $NODE nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits | \
+        awk -F', ' -v node=$NODE '$2 > 100 {found=1; print "DIRTY GPU "$1" on "node} END {if(found) exit 1}'
+done
+echo "=== All GPUs clean ==="
+
+# --- Step 1: Per-node setup ---
+# The setup logic runs inline via heredoc to avoid temp file management.
+# Each node: Docker cleanup -> container start -> Ray start -> code sync -> venv -> model download
+setup_node() {
+    local NODE=$1
+    local ROLE=$2       # "head" or "worker"
+    local CONTAINER=$3  # container name
+    local RAY_CMD=$4    # ray start command
+
+    run_on $NODE bash -s "$ROLE" "$CONTAINER" "$RAY_CMD" "$HEAD_NODE" "$DOCKER_IMAGE" \
+        "$DOCKER_ROOT" "$SCRATCH_DIR" "$SKYRL_HOST_DIR" "$THUNDERAGENT_HOST_DIR" \
+        "$NCCL_SOCKET_IFNAME" "$NCCL_IB_DISABLE" << 'NODE_SETUP_EOF'
+#!/bin/bash
+set -e
+ROLE=$1
+CONTAINER=$2
+RAY_CMD=$3
+HEAD_NODE=$4
+DOCKER_IMAGE=$5
+DOCKER_ROOT=$6
+SCRATCH_DIR=$7
+SKYRL_HOST_DIR=$8
+THUNDERAGENT_HOST_DIR=$9
+
+NCCL_SOCKET_IFNAME=${10}
+NCCL_IB_DISABLE=${11}
+
+DOCKER_GID=$(getent group docker | cut -d: -f3)
+
+echo "=== Node $(hostname): Setup as $ROLE ==="
+
+sudo usermod -aG docker $USER 2>/dev/null || true
+
+# Verify Docker is running
+sg docker -c "docker info" > /dev/null 2>&1 || {
+    echo "Docker not responding, restarting..."
+    sudo systemctl restart docker
+    sleep 5
+}
+
+# Cleanup old containers
+sg docker -c "docker rm -f $CONTAINER 2>/dev/null || true"
+sg docker -c "docker ps -a --filter name=minisweagent -q | xargs -r docker rm -f 2>/dev/null || true"
+sg docker -c "docker system prune -f 2>/dev/null || true"
+
+# Verify image exists
+if ! sg docker -c "docker image inspect $DOCKER_IMAGE" > /dev/null 2>&1; then
+    echo "Image missing on $(hostname) - pulling..."
+    sg docker -c "docker pull $DOCKER_IMAGE"
+fi
+
+# Extra env vars: DOCKER_NODE_RESOURCE only on head node
+EXTRA_ENV=""
+if [ "$ROLE" = "head" ]; then
+    EXTRA_ENV="-e DOCKER_NODE_RESOURCE=1"
+fi
+
+# Read HF_TOKEN from api-keys.sh (sourced inside subshell to avoid polluting env)
+HF_TOKEN=$(bash -c "source $SKYRL_HOST_DIR/api-keys.sh 2>/dev/null && echo \$HF_TOKEN" || echo "")
+
+# Start container
+# NCCL logs redirected to /scratch/nccl_logs/ to keep training output clean
+sg docker -c "docker run -d --gpus all --cpuset-cpus=0-167 --shm-size=16g \
+  --group-add $DOCKER_GID \
+  --network=host --name $CONTAINER \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /usr/bin/docker:/usr/bin/docker \
+  -v $SKYRL_HOST_DIR:/workspace/SkyRL \
+  -v $THUNDERAGENT_HOST_DIR:/workspace/ThunderAgent-wl \
+  -v $SCRATCH_DIR:/scratch \
+  -e RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook \
+  -e RAY_task_events_report_worker_events=false \
+  -e DATA=/scratch -e HOME=/scratch \
+  -e UV_CACHE_DIR=/scratch/uv_cache -e UV_PYTHON_INSTALL_DIR=/scratch/uv_python \
+  -e HF_HOME=/scratch/hf_cache -e HUGGINGFACE_HUB_CACHE=/scratch/hf_cache -e HF_TOKEN=$HF_TOKEN \
+  -e FLASHINFER_WORKSPACE_DIR=/scratch/flashinfer_cache \
+  -e TRITON_CACHE_DIR=/scratch/triton_cache \
+  -e XDG_CACHE_HOME=/scratch/cache \
+  -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+  -e NCCL_DEBUG=INFO -e NCCL_DEBUG_SUBSYS=INIT,COLL \
+  -e NCCL_DEBUG_FILE=/scratch/nccl_logs/nccl_%h_%p.log \
+  -e NCCL_SOCKET_IFNAME=$NCCL_SOCKET_IFNAME \
+  -e NCCL_IB_DISABLE=$NCCL_IB_DISABLE \
+  -e CPATH=/scratch/SkyRL/skyrl-train/.venv/lib/python3.12/site-packages/nvidia/cudnn/include:/scratch/SkyRL/skyrl-train/.venv/lib/python3.12/site-packages/nvidia/nccl/include \
+  -e CUDA_HOME=/usr/local/cuda \
+  -e NVTE_FRAMEWORK=pytorch -e NVTE_WITH_USERBUFFERS=1 \
+  $EXTRA_ENV \
+  $DOCKER_IMAGE \
+  bash -c 'mkdir -p /scratch/nccl_logs && sleep infinity'"
+echo "$(hostname): Container $CONTAINER started"
+
+# Start Ray inside the container
+sleep 2
+sg docker -c "docker exec -i $CONTAINER bash" << RAYEOF
+ray stop --force 2>/dev/null || true
+$RAY_CMD
+RAYEOF
+echo "$(hostname): Ray started"
+
+# Sync code inside container
+sg docker -c "docker exec $CONTAINER bash -c '
+  timeout 180 rsync -a --delete \
+    --exclude training_data --exclude slurm-\\* --exclude .git --exclude __pycache__ \
+    --exclude .claude --exclude .venv --exclude .tmp_\\* --exclude exp_\\* \
+    --exclude \\*.png --exclude \\*.jpg --exclude docker/ --exclude training_data/ \
+    --timeout=120 \
+    /workspace/SkyRL/ /scratch/SkyRL/ 2>/dev/null
+  RSYNC1=\$?
+  timeout 60 rsync -a --delete --exclude .git --exclude __pycache__ --timeout=60 \
+    /workspace/ThunderAgent-wl/ /scratch/ThunderAgent-wl/ 2>/dev/null
+  RSYNC2=\$?
+  if [ \$RSYNC1 -ne 0 ] || [ \$RSYNC2 -ne 0 ]; then
+    echo \"WARNING: rsync incomplete (SkyRL=\$RSYNC1, ThunderAgent=\$RSYNC2), using pre-copied or cached code\"
+  fi
+  test -f /scratch/SkyRL/skyrl-train/skyrl_train/__init__.py && echo \"Code OK\" || echo \"ERROR: code missing\"
+'" || echo "$(hostname): WARNING - rsync had issues, proceeding anyway"
+echo "$(hostname): Code synced"
+
+# Install venv if missing, verify cached environment
+sg docker -c "docker exec $CONTAINER bash -c '
+  cd /scratch/SkyRL/skyrl-train
+  if ! .venv/bin/python --version > /dev/null 2>&1; then
+    echo \"$(hostname): Venv missing - installing...\"
+    uv sync --extra mcore --extra miniswe 2>&1 | tail -3
+  fi
+  echo \"Venv: \$(.venv/bin/python --version 2>&1 || echo MISSING)\"
+  .venv/bin/python -c \"import megatron.core; print(f\\\"megatron-core {megatron.core.__version__}\\\")\" 2>&1 || echo \"megatron-core import FAILED\"
+
+  # Download model if missing
+  MODEL_SHARDS=\$(ls /scratch/models/Qwen3-32B/*.safetensors 2>/dev/null | wc -l)
+  echo \"Model: \$MODEL_SHARDS shards\"
+  if [ \"\$MODEL_SHARDS\" -lt 17 ]; then
+    echo \"$(hostname): Model incomplete - downloading...\"
+    mkdir -p /scratch/models/Qwen3-32B
+    .venv/bin/huggingface-cli download Qwen/Qwen3-32B --local-dir /scratch/models/Qwen3-32B 2>&1 | tail -3
+    echo \"Model: \$(ls /scratch/models/Qwen3-32B/*.safetensors 2>/dev/null | wc -l) shards (after download)\"
+  fi
+
+  echo \"Dataset: \$(ls /scratch/data/swe_gym/*.parquet 2>/dev/null | wc -l) parquets\"
+'"
+
+# Only on head node: symlink cuDNN/NCCL headers + check SWE-bench images
+if [ "$ROLE" = "head" ]; then
+    sg docker -c "docker exec -u root $CONTAINER bash -c '
+      VENV=/scratch/SkyRL/skyrl-train/.venv/lib/python3.12/site-packages/nvidia
+      for f in \$VENV/cudnn/include/cudnn*.h; do ln -sf \$f /usr/local/cuda/include/; done 2>/dev/null
+      for f in \$VENV/nccl/include/nccl*.h; do ln -sf \$f /usr/local/cuda/include/; done 2>/dev/null
+      for f in \$VENV/cudnn/lib/libcudnn*.so*; do ln -sf \$f /usr/local/cuda/lib64/; done 2>/dev/null
+      for f in \$VENV/nccl/lib/libnccl*.so*; do ln -sf \$f /usr/local/cuda/lib64/; done 2>/dev/null
+      echo \"cuDNN/NCCL headers symlinked\"
+    '"
+    SWEB_COUNT=$(sg docker -c "docker exec $CONTAINER bash -c 'docker images --format \"{{.Repository}}\" 2>/dev/null | grep -c sweb || echo 0'")
+    echo "$(hostname): SWE-bench images cached: $SWEB_COUNT"
+fi
+
+echo "=== $(hostname) setup complete ==="
+NODE_SETUP_EOF
+}
+
+# --- Step 2a: Setup HEAD node first (Ray head must be ready before workers) ---
+echo "=== Setting up HEAD node first ==="
+setup_node "$HEAD_NODE" head skyrl-head \
+    "ray start --head --port=6379 --dashboard-host=0.0.0.0 --num-gpus=0 --resources='{\"docker_node\": 128}'"
+echo "=== Head node setup complete (Ray GCS ready on ${HEAD_NODE}:6379) ==="
+
+# --- Step 2b: Setup 5 worker nodes in parallel (Ray head is guaranteed ready) ---
+echo "=== Setting up 5 worker nodes in parallel ==="
+
+setup_node "$INFERENCE_NODE" worker skyrl-worker \
+    "ray start --address=${HEAD_NODE}:6379" &
+INF_PID=$!
+
+setup_node "$TRAINING_NODE_0" worker skyrl-worker \
+    "ray start --address=${HEAD_NODE}:6379" &
+TRAIN0_PID=$!
+
+setup_node "$TRAINING_NODE_1" worker skyrl-worker \
+    "ray start --address=${HEAD_NODE}:6379" &
+TRAIN1_PID=$!
+
+setup_node "$TRAINING_NODE_2" worker skyrl-worker \
+    "ray start --address=${HEAD_NODE}:6379" &
+TRAIN2_PID=$!
+
+setup_node "$TRAINING_NODE_3" worker skyrl-worker \
+    "ray start --address=${HEAD_NODE}:6379" &
+TRAIN3_PID=$!
+
+wait $INF_PID
+echo "=== Inference node setup complete ==="
+wait $TRAIN0_PID
+echo "=== Training node PP0 setup complete ==="
+wait $TRAIN1_PID
+echo "=== Training node PP1 setup complete ==="
+wait $TRAIN2_PID
+echo "=== Training node PP2 setup complete ==="
+wait $TRAIN3_PID
+echo "=== Training node PP3 setup complete ==="
+
+sleep 15
+echo "=== Ray cluster status ==="
+run_on $HEAD_NODE sg docker -c "docker exec skyrl-head ray status"
+
+# --- Step 3: Pre-pull SWE-bench images in background ---
+echo "=== Starting SWE-bench image pre-pull in background ==="
+run_on $HEAD_NODE sg docker -c "docker exec skyrl-head bash -c '
+  export HF_HOME=/scratch/hf_cache
+  cd /scratch/SkyRL/skyrl-train
+  EXISTING=\$(docker images --format \"{{.Repository}}\" 2>/dev/null | grep -c sweb || echo 0)
+  echo \"Pre-pull: \$EXISTING SWE-bench images already cached\"
+  if [ \$EXISTING -lt 2400 ]; then
+    nohup uv run --isolated python /scratch/SkyRL/skyrl-train/examples/mini_swe_agent/pull_swebench_images.py \
+      --train_dataset SumanthRH/SWE-Gym \
+      --train_only \
+      --parallel 8 \
+      > /scratch/prepull_swebench.log 2>&1 &
+    echo \"Pre-pull started (PID=\$!), log at /scratch/prepull_swebench.log\"
+  else
+    echo \"All images cached, skipping pre-pull\"
+  fi
+'" &
+PREPULL_PID=$!
+echo "=== SWE-bench pre-pull launched (host PID=$PREPULL_PID) ==="
+
+# --- Step 4: Background NFS sync ---
+JOB_SYNC_DEST="$TRAINING_DATA_SYNC_DEST/job_${SLURM_JOB_ID_SAFE}_32b_megatron_${ROUTER_TAG}"
+mkdir -p "$JOB_SYNC_DEST"
+(while true; do
+    sleep 60
+    for d in $SCRATCH_DIR/mini_swe_agent_trajs $SCRATCH_DIR/profiler_data $SCRATCH_DIR/thunderagent_profiles; do
+        [ -d "$d" ] && rsync -a --ignore-errors "$d" "$JOB_SYNC_DEST/" 2>/dev/null
+    done
+done) &
+SYNC_PID=$!
+echo "=== Background sync started (PID=$SYNC_PID) -> $JOB_SYNC_DEST ==="
+
+# --- Step 5: Launch training on HEAD node ---
+RUN_NAME="mini_swe_32B_megatron_${ROUTER_TAG}"
+DOCKER_ENV_ARGS="-e THUNDERAGENT_ROUTER=$ROUTER_MODE -e SLURM_JOB_ID=$SLURM_JOB_ID_SAFE"
+DOCKER_ENV_ARGS="$DOCKER_ENV_ARGS -e HEAD_NODE=$HEAD_NODE -e DOCKER_NODE_RESOURCE=1"
+if [ -n "$ACTING_TOKEN_WEIGHT" ]; then
+  DOCKER_ENV_ARGS="$DOCKER_ENV_ARGS -e ACTING_TOKEN_WEIGHT=$ACTING_TOKEN_WEIGHT"
+fi
+
+if [ -n "$ACTING_TOKEN_WEIGHT" ]; then
+  echo "=== Launching 32B Megatron training with router=$ROUTER_MODE acting_token_weight=$ACTING_TOKEN_WEIGHT ==="
+else
+  echo "=== Launching 32B Megatron training with router=$ROUTER_MODE ==="
+fi
+echo "=== $(date) ==="
+
+set +e
+run_on $HEAD_NODE sg docker -c "docker exec $DOCKER_ENV_ARGS skyrl-head \
+  bash /scratch/SkyRL/launch_training_32b_megatron.sh \
+  trainer.run_name=$RUN_NAME \
+  trainer.policy.record_memory=true \
+  trainer.ckpt_interval=10"
+TRAIN_EXIT=$?
+set -e
+
+# --- Cleanup ---
+kill "$SYNC_PID" 2>/dev/null || true
+echo "=== Background sync stopped ==="
+
+echo "=== Job finished at $(date), exit=$TRAIN_EXIT ==="
+exit "$TRAIN_EXIT"

--- a/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/litellm.json
+++ b/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/litellm.json
@@ -58,5 +58,11 @@
         "output_cost_per_token": 0.0,
         "mode": "chat",
         "max_tokens": 64000
+    },
+    "openai/Qwen/Qwen3-32B": {
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "mode": "chat",
+        "max_tokens": 40960
     }
 }

--- a/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/main_mini_swe_fully_async.py
+++ b/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/main_mini_swe_fully_async.py
@@ -1,0 +1,102 @@
+"""
+Main entrypoint for fully async mini-SWE-agent training.
+
+Combines MiniSweAgentGenerator (multi-turn Docker-based SWE agent) with
+FullyAsyncRayPPOTrainer (overlapping generation and training).
+"""
+
+import asyncio
+
+import hydra
+import ray
+from omegaconf import DictConfig, OmegaConf, open_dict
+
+from skyrl_train.entrypoints.main_base import config_dir, validate_cfg
+from skyrl_train.fully_async_trainer import FullyAsyncRayPPOTrainer
+from skyrl_train.utils import initialize_ray
+
+from .main_mini_swe import MiniSWEPPOExp
+
+
+class MiniSWEFullyAsyncPPOExp(MiniSWEPPOExp):
+    """Mini-SWE-agent experiment with fully async training."""
+
+    def get_trainer(
+        self,
+        cfg,
+        tracker,
+        tokenizer,
+        train_dataset,
+        eval_dataset,
+        inference_engine_client,
+        generator,
+        colocate_pg,
+    ):
+        return FullyAsyncRayPPOTrainer(
+            cfg=cfg,
+            tracker=tracker,
+            tokenizer=tokenizer,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            inference_engine_client=inference_engine_client,
+            generator=generator,
+            colocate_pg=colocate_pg,
+        )
+
+    def run(self):
+        trainer = self._setup_trainer()
+        asyncio.run(trainer.train())
+
+
+@ray.remote(num_cpus=1)
+def skyrl_entrypoint(cfg: DictConfig):
+    import os
+    import sys
+    import traceback
+
+    model_path = cfg.trainer.policy.model.path
+
+    # If model_path is already a local directory (e.g., flat copy at /scratch/models/...),
+    # use it directly. Otherwise, resolve via snapshot_download.
+    if os.path.isdir(model_path):
+        local_path = model_path
+    else:
+        from huggingface_hub import snapshot_download
+
+        local_path = snapshot_download(model_path)
+
+    with open_dict(cfg):
+        cfg.trainer.policy.model.path = local_path
+
+    try:
+        exp = MiniSWEFullyAsyncPPOExp(cfg)
+        exp.run()
+    except Exception as e:
+        print(f"\n{'='*80}", file=sys.stderr)
+        print(f"FATAL: skyrl_entrypoint crashed: {e}", file=sys.stderr)
+        print(f"{'='*80}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        print(f"{'='*80}\n", file=sys.stderr)
+        raise
+
+
+@hydra.main(config_path=config_dir, config_name="ppo_base_config", version_base=None)
+def main(cfg: DictConfig) -> None:
+    import sys
+    import traceback
+
+    validate_cfg(cfg)
+    initialize_ray(cfg)
+    try:
+        ray.get(skyrl_entrypoint.remote(cfg))
+    except Exception as e:
+        print(f"\n{'='*80}", file=sys.stderr)
+        print(f"FATAL: Training failed: {e}", file=sys.stderr)
+        print(f"{'='*80}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        print(f"{'='*80}\n", file=sys.stderr)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/mini_swe_generator.py
+++ b/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/mini_swe_generator.py
@@ -25,6 +25,8 @@ from skyrl_train.generators.utils import (
     get_rollout_metrics,
     get_response_ids_and_loss_mask_from_messages,
 )
+from skyrl_train.env_vars import SKYRL_GENERATION_TASK_TIMEOUT_S, SKYRL_GENERATION_BATCH_TIMEOUT_S
+from loguru import logger
 
 
 class DefaultAgentWithReminder(DefaultAgent):
@@ -82,7 +84,7 @@ class DefaultAgentWithReminder(DefaultAgent):
         return output
 
 
-@ray.remote(num_cpus=0.01)
+@ray.remote(num_cpus=0.01, enable_task_events=False)
 def init_and_run(
     instance: dict,
     litellm_model_name: str,
@@ -126,6 +128,14 @@ def init_and_run(
         error = str(e)
         extra_info = {"traceback": traceback.format_exc()}
     finally:
+        # Cleanup agent Docker container immediately to prevent accumulation.
+        # Without this, containers pile up (2 per trajectory) and crash the Docker daemon.
+        if env is not None:
+            try:
+                env.cleanup()
+            except Exception:
+                pass
+
         # Create trajectory directory with proper structure: step_{global_step}/{train/eval}
         path = Path(generator_cfg.miniswe_traj_dir) / f"step_{global_step}" / training_phase
         path.mkdir(parents=True, exist_ok=True)
@@ -209,17 +219,23 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
         self,
         prompt: ConversationType,
         messages: Optional[List[Dict[str, Any]]] = None,
+        stop_reason: str = "error",
     ) -> Tuple[List[int], float, str, List[int], List[int], None]:
         """Create a valid dummy output for failed trajectories.
 
         Returns data that passes all downstream trainer checks but contributes
         zero to training (reward=0, loss_mask all zeros, single EOS token).
+
+        Args:
+            stop_reason: Why this dummy was created. One of "timeout" (per-task
+                ObjectRef timeout), "batch_timeout" (batch-level safety net),
+                "error" (unexpected exception or empty messages).
         """
         eos_token_id = self.tokenizer.eos_token_id
         dummy_response_ids = [eos_token_id]
         dummy_loss_mask = [0]
         dummy_reward = 0.0
-        dummy_stop_reason = "error"
+        dummy_stop_reason = stop_reason
 
         # Construct prompt_ids from available messages
         try:
@@ -251,71 +267,100 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
         batch_metadata: BatchMetadata,
     ) -> Tuple[List[int], float, str, List[int], List[int], Optional[List[int]]]:
 
-        sweagent_config = yaml.safe_load(get_config_path(self.generator_cfg.miniswe_config_path).read_text())
-        # NOTE (sumanthrh): Input `prompt` is not used here because mini-swe-agent uses a similar entry from the `instance` obj
-        messages, reward, error, step_timings = await init_and_run.remote(
-            env_extras["instance"],
-            self.litellm_model_name,
-            sweagent_config,
-            self.generator_cfg,
-            env_extras["data_source"],
-            sampling_params,
-            trajectory_id,
-            batch_metadata.global_step,
-            batch_metadata.training_phase,
-        )
-        if not len(messages):
-            from loguru import logger
-            logger.warning(f"Empty messages for trajectory {trajectory_id}. Returning dummy output.")
-            return self._make_dummy_output(prompt)
+        obj_ref = None
+        try:
+            sweagent_config = yaml.safe_load(get_config_path(self.generator_cfg.miniswe_config_path).read_text())
+            # NOTE (sumanthrh): Input `prompt` is not used here because mini-swe-agent uses a similar entry from the `instance` obj
+            # Optionally pin init_and_run tasks to Docker-capable nodes (e.g., head node in 2-node setup)
+            remote_fn = init_and_run
+            if os.environ.get("DOCKER_NODE_RESOURCE"):
+                remote_fn = init_and_run.options(resources={"docker_node": 0.01}, enable_task_events=False)
 
-        # TODO (sumanthrh): This is currently hardcoded for SWEBench with 2 initial messages (system and user).
-        response_messages = messages[2:]
-
-        for message in messages[:2]:
-            assert message["role"] in (
-                "system",
-                "user",
-            ), "Expected the first two messages to be system and user messages"
-
-        initial_input_ids = self.tokenizer.apply_chat_template(messages[:2], add_generation_prompt=False, tokenize=True)
-        initial_prompt_length = len(initial_input_ids)
-
-        # We remove trailing `user` messages - this is added by Mini-SWE-Agent to capture the final git diff for the trajectory
-        last_idx = len(response_messages) - 1
-        while last_idx >= 0 and response_messages[last_idx]["role"] == "user":
-            last_idx -= 1
-        if last_idx < 0:
-            from loguru import logger
-            logger.warning(
-                "Found no assistant messages for this trajectory. Returning dummy output. "
-                "Please ensure that your environment is configured correctly and the `OPENAI_BASE_URL` points to the HTTP server from the inference engine client"
+            obj_ref = remote_fn.remote(
+                env_extras["instance"],
+                self.litellm_model_name,
+                sweagent_config,
+                self.generator_cfg,
+                env_extras["data_source"],
+                sampling_params,
+                trajectory_id,
+                batch_metadata.global_step,
+                batch_metadata.training_phase,
             )
-            return self._make_dummy_output(prompt, messages)
-        response_messages = response_messages[: last_idx + 1]
+            try:
+                messages, reward, error, step_timings = await asyncio.wait_for(
+                    obj_ref, timeout=SKYRL_GENERATION_TASK_TIMEOUT_S
+                )
+            except asyncio.TimeoutError:
+                ray.cancel(obj_ref, force=True)
+                logger.warning(
+                    f"Ray task timed out after {SKYRL_GENERATION_TASK_TIMEOUT_S}s for "
+                    f"{trajectory_id}. Using dummy output."
+                )
+                return self._make_dummy_output(prompt, stop_reason="timeout")
 
-        response_ids, loss_mask, _ = get_response_ids_and_loss_mask_from_messages(
-            response_messages,
-            self.tokenizer,
-            assistant_logprobs=None,
-        )
+            if not len(messages):
+                logger.warning(f"Empty messages for trajectory {trajectory_id}. Returning dummy output.")
+                return self._make_dummy_output(prompt)
 
-        # Extract prompt ids
-        prompt_ids = initial_input_ids
+            # TODO (sumanthrh): This is currently hardcoded for SWEBench with 2 initial messages (system and user).
+            response_messages = messages[2:]
 
-        # Calculate maximum response tokens allowed
-        max_response_tokens = max_tokens + max_input_length - initial_prompt_length
+            for message in messages[:2]:
+                assert message["role"] in (
+                    "system",
+                    "user",
+                ), "Expected the first two messages to be system and user messages"
 
-        # Determine stop reason
-        stop_reason = "complete"  # Default for trial completion
-        if len(response_ids) > max_response_tokens:
-            stop_reason = "length"
+            initial_input_ids = self.tokenizer.apply_chat_template(
+                messages[:2], add_generation_prompt=False, tokenize=True
+            )
+            initial_prompt_length = len(initial_input_ids)
 
-        # Truncate to maximum allowed length
-        response_ids = response_ids[:max_response_tokens]
-        loss_mask = loss_mask[:max_response_tokens]
+            # We remove trailing `user` messages - this is added by Mini-SWE-Agent to capture the final git diff for the trajectory
+            last_idx = len(response_messages) - 1
+            while last_idx >= 0 and response_messages[last_idx]["role"] == "user":
+                last_idx -= 1
+            if last_idx < 0:
+                logger.warning(
+                    "Found no assistant messages for this trajectory. Returning dummy output. "
+                    "Please ensure that your environment is configured correctly and the `OPENAI_BASE_URL` points to the HTTP server from the inference engine client"
+                )
+                return self._make_dummy_output(prompt, messages)
+            response_messages = response_messages[: last_idx + 1]
 
-        return (response_ids, reward, stop_reason, loss_mask, prompt_ids, None)
+            response_ids, loss_mask, _ = get_response_ids_and_loss_mask_from_messages(
+                response_messages,
+                self.tokenizer,
+                assistant_logprobs=None,
+            )
+
+            # Extract prompt ids
+            prompt_ids = initial_input_ids
+
+            # Calculate maximum response tokens allowed
+            max_response_tokens = max_tokens + max_input_length - initial_prompt_length
+
+            # Determine stop reason
+            stop_reason = "complete"  # Default for trial completion
+            if len(response_ids) > max_response_tokens:
+                stop_reason = "length"
+
+            # Truncate to maximum allowed length
+            response_ids = response_ids[:max_response_tokens]
+            loss_mask = loss_mask[:max_response_tokens]
+
+            return (response_ids, reward, stop_reason, loss_mask, prompt_ids, None)
+
+        except asyncio.CancelledError:
+            # Batch timeout cancelled us — also cancel the underlying Ray task
+            if obj_ref is not None:
+                ray.cancel(obj_ref, force=True)
+            raise  # must re-raise CancelledError per asyncio contract
+
+        except Exception as e:
+            logger.warning(f"Unexpected error in trajectory {trajectory_id}: {e}")
+            return self._make_dummy_output(prompt)
 
     async def _collect_vllm_metrics(self, step: int, metrics_log: list, interval: float = 2.0):
         """Background task to collect vLLM metrics every `interval` seconds during rollout."""
@@ -363,8 +408,6 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
             self._collect_vllm_metrics(batch_metadata.global_step, vllm_metrics_log)
         )
 
-        from loguru import logger
-
         # Rate-limit Docker container launches: start trajectories in batches
         # to avoid overwhelming the Docker daemon with simultaneous container creation.
         ROLLOUT_BATCH_SIZE = 64
@@ -374,41 +417,86 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
         total = len(prompts)
         total_batches = (total + ROLLOUT_BATCH_SIZE - 1) // ROLLOUT_BATCH_SIZE
 
-        for batch_start in range(0, total, ROLLOUT_BATCH_SIZE):
-            batch_end = min(batch_start + ROLLOUT_BATCH_SIZE, total)
-            batch_num = batch_start // ROLLOUT_BATCH_SIZE + 1
-
-            if batch_start > 0:
-                logger.info(
-                    f"Rollout batch {batch_num}/{total_batches}: waiting {ROLLOUT_BATCH_DELAY}s before launching next batch..."
-                )
-                await asyncio.sleep(ROLLOUT_BATCH_DELAY)
-
-            logger.info(
-                f"Rollout batch {batch_num}/{total_batches}: launching {batch_end - batch_start} trajectories [{batch_start}:{batch_end}]"
-            )
-            for i in range(batch_start, batch_end):
-                task = asyncio.create_task(
-                    self.minisweagent_agent_loop(
-                        prompts[i],
-                        env_extras[i],
-                        max_tokens=max_tokens,
-                        max_input_length=max_input_length,
-                        sampling_params=sampling_params,
-                        trajectory_id=trajectory_ids[i],
-                        batch_metadata=batch_metadata,
-                    )
-                )
-                all_tasks.append(task)
-
-        all_outputs = await asyncio.gather(*all_tasks)
-
-        # Stop background metrics collection
-        metrics_task.cancel()
         try:
-            await metrics_task
-        except asyncio.CancelledError:
-            pass
+            for batch_start in range(0, total, ROLLOUT_BATCH_SIZE):
+                batch_end = min(batch_start + ROLLOUT_BATCH_SIZE, total)
+                batch_num = batch_start // ROLLOUT_BATCH_SIZE + 1
+
+                if batch_start > 0:
+                    logger.info(
+                        f"Rollout batch {batch_num}/{total_batches}: waiting {ROLLOUT_BATCH_DELAY}s before launching next batch..."
+                    )
+                    await asyncio.sleep(ROLLOUT_BATCH_DELAY)
+
+                logger.info(
+                    f"Rollout batch {batch_num}/{total_batches}: launching {batch_end - batch_start} trajectories [{batch_start}:{batch_end}]"
+                )
+                for i in range(batch_start, batch_end):
+                    task = asyncio.create_task(
+                        self.minisweagent_agent_loop(
+                            prompts[i],
+                            env_extras[i],
+                            max_tokens=max_tokens,
+                            max_input_length=max_input_length,
+                            sampling_params=sampling_params,
+                            trajectory_id=trajectory_ids[i],
+                            batch_metadata=batch_metadata,
+                        )
+                    )
+                    all_tasks.append(task)
+
+            done, pending = await asyncio.wait(all_tasks, timeout=SKYRL_GENERATION_BATCH_TIMEOUT_S)
+
+            if pending:
+                logger.warning(
+                    f"generate() batch timeout: {len(done)} completed, {len(pending)} timed out. "
+                    f"Cancelling pending tasks."
+                )
+                for task in pending:
+                    task.cancel()
+                # Wait for cancellation to propagate (triggers CancelledError handler in minisweagent_agent_loop)
+                await asyncio.gather(*pending, return_exceptions=True)
+
+            # Reconstruct ordered outputs: real result for done, dummy for timed-out/failed
+            all_outputs = []
+            for i, task in enumerate(all_tasks):
+                if task.done() and not task.cancelled():
+                    try:
+                        all_outputs.append(task.result())
+                    except Exception as e:
+                        logger.warning(f"Task {i} raised exception: {e}. Using dummy output.")
+                        all_outputs.append(self._make_dummy_output(prompts[i], stop_reason="error"))
+                else:
+                    all_outputs.append(self._make_dummy_output(prompts[i], stop_reason="batch_timeout"))
+
+            # Compute accurate counts from stop_reason (captures per-task timeouts that completed normally)
+            stop_reasons = [output[2] for output in all_outputs]
+            num_timeouts = stop_reasons.count("timeout")
+            num_batch_timeouts = stop_reasons.count("batch_timeout")
+            num_errors = stop_reasons.count("error")
+            num_real = len(all_outputs) - num_timeouts - num_batch_timeouts - num_errors
+            logger.info(
+                f"generate() complete: {num_real} real, {num_timeouts} task_timeouts, "
+                f"{num_batch_timeouts} batch_timeouts, {num_errors} errors "
+                f"out of {len(all_outputs)} total "
+                f"(dummy_rate={100 * (num_timeouts + num_batch_timeouts + num_errors) / max(len(all_outputs), 1):.1f}%)"
+            )
+
+        finally:
+            # Guarantee cleanup on any exit (normal, exception, or external cancellation)
+            # Cancel all in-flight rollout tasks so CancelledError handlers run and call ray.cancel()
+            for task in all_tasks:
+                if not task.done():
+                    task.cancel()
+            if all_tasks:
+                await asyncio.gather(*all_tasks, return_exceptions=True)
+
+            # Stop background metrics collection
+            metrics_task.cancel()
+            try:
+                await metrics_task
+            except asyncio.CancelledError:
+                pass
 
         # Save vLLM metrics to file
         if vllm_metrics_log:

--- a/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/mini_swe_utils.py
+++ b/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/mini_swe_utils.py
@@ -68,23 +68,31 @@ def evaluate_trajectory(
     # NOTE (sumanthrh): This applies patch in-line, and the maximum patch size is limited by the OS limits for `ARG_MAX`.
     # In modern systems, this is typically ~ 1 MB, which is pretty generous.
     # For simplicity, we assume that large patches greater than `ARG_MAX` are meant to fail
-    delimiter = f"PATCH_{uuid.uuid4().hex}"  # unlikely to collide with symbols in the patch
-    command = f"git apply <<'{delimiter}'\n{model_patch}\n{delimiter}"
+    try:
+        delimiter = f"PATCH_{uuid.uuid4().hex}"  # unlikely to collide with symbols in the patch
+        command = f"git apply <<'{delimiter}'\n{model_patch}\n{delimiter}"
 
-    obs = env.execute(command)
+        obs = env.execute(command)
 
-    if obs["returncode"] != 0:
-        ret["eval_error"] = obs["output"]
-    else:
-        # run eval script in-line
-        eval_script = instance["eval_script"]
-        eval_cmd = f"bash <<'EOF'\n{eval_script}\nEOF"
-        # add longer timeout for evaluation
-        obs = env.execute(eval_cmd, timeout=3600)
-        # use the return value
-        ret["resolved"] = obs["returncode"] == 0
-        # truncate to last 1000 characters for brevity
-        ret["eval_error"] = (
-            f"(truncated to last 1000 characters)\n{obs["output"][-1000:]}" if not ret["resolved"] else None
-        )
+        if obs["returncode"] != 0:
+            ret["eval_error"] = obs["output"]
+        else:
+            # run eval script in-line
+            eval_script = instance["eval_script"]
+            eval_cmd = f"bash <<'EOF'\n{eval_script}\nEOF"
+            # add longer timeout for evaluation
+            obs = env.execute(eval_cmd, timeout=3600)
+            # use the return value
+            ret["resolved"] = obs["returncode"] == 0
+            # truncate to last 1000 characters for brevity
+            ret["eval_error"] = (
+                f"(truncated to last 1000 characters)\n{obs["output"][-1000:]}" if not ret["resolved"] else None
+            )
+    finally:
+        # Cleanup eval Docker container immediately to prevent accumulation
+        if env is not None:
+            try:
+                env.cleanup()
+            except Exception:
+                pass
     return ret

--- a/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/preprocess_swegym.py
+++ b/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/preprocess_swegym.py
@@ -10,12 +10,13 @@ import datasets
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--output_dir", default="~/data/swe_gym_subset")
+    parser.add_argument("--train_dataset", default="SumanthRH/SWE-Gym-Subset")
 
     args = parser.parse_args()
 
     args.output_dir = os.path.expanduser(args.output_dir)
 
-    data_source = "SumanthRH/SWE-Gym-Subset"
+    data_source = args.train_dataset
     eval_data_source = "SumanthRH/SWE-bench_Verified"
 
     train_dataset = datasets.load_dataset(data_source, "default")["train"]

--- a/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/pull_swebench_images.py
+++ b/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/pull_swebench_images.py
@@ -1,0 +1,121 @@
+"""
+Pre-pull SWE-bench Docker images required by the training/eval dataset.
+
+Reads the parquet data files, computes Docker image names using the same logic
+as mini_swe_utils.get_docker_image_name(), and pulls them in parallel.
+
+Usage:
+    python pull_swebench_images.py --data_dir /scratch/data/swe_gym_subset [--parallel 4]
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import pandas as pd
+
+
+def get_docker_image_name(instance_id: str, data_source: str) -> str:
+    """Mirror of mini_swe_utils.get_docker_image_name logic."""
+    if "swe-gym" in data_source.lower():
+        id_docker = instance_id.replace("__", "_s_")
+        return f"xingyaoww/sweb.eval.x86_64.{id_docker}:latest".lower()
+    elif "swe-bench" in data_source.lower():
+        id_docker = instance_id.replace("__", "_1776_")
+        return f"swebench/sweb.eval.x86_64.{id_docker}:latest".lower()
+    else:
+        raise ValueError(f"Unknown data_source: {data_source}")
+
+
+CORRUPTION_PATTERNS = ["invalid tar header", "invalid deflate data", "layers from manifest don't match"]
+
+
+def _is_corruption_error(msg: str) -> bool:
+    return any(p in msg for p in CORRUPTION_PATTERNS)
+
+
+def pull_image(image: str) -> tuple[str, bool, str]:
+    """Pull a single Docker image. Returns (image, success, message).
+
+    If the pull fails due to corrupted cached layers, removes the image
+    and retries once.
+    """
+    for attempt in range(2):
+        try:
+            result = subprocess.run(
+                ["docker", "pull", image],
+                capture_output=True, text=True, timeout=600,
+            )
+            if result.returncode == 0:
+                return (image, True, "ok")
+            err = result.stderr.strip().split("\n")[-1] if result.stderr else "unknown"
+            if attempt == 0 and _is_corruption_error(err):
+                # Remove corrupted cached layers and retry
+                subprocess.run(["docker", "rmi", "-f", image], capture_output=True, timeout=60)
+                continue
+            return (image, False, err)
+        except subprocess.TimeoutExpired:
+            return (image, False, "timeout")
+        except Exception as e:
+            return (image, False, str(e))
+    return (image, False, "failed after retry")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data_dir", required=True, help="Directory with train.parquet and validation.parquet")
+    parser.add_argument("--parallel", type=int, default=4, help="Number of parallel pulls")
+    parser.add_argument("--train_only", action="store_true", help="Only pull training images (skip eval)")
+    args = parser.parse_args()
+
+    # Collect unique images from dataset
+    images = set()
+    parquet_files = [("train", os.path.join(args.data_dir, "train.parquet"))]
+    if not args.train_only:
+        parquet_files.append(("validation", os.path.join(args.data_dir, "validation.parquet")))
+
+    for split, path in parquet_files:
+        if not os.path.exists(path):
+            print(f"WARNING: {path} not found, skipping {split}")
+            continue
+        df = pd.read_parquet(path)
+        for _, row in df.iterrows():
+            instance = row["instance"]
+            iid = instance["instance_id"] if isinstance(instance, dict) else instance.get("instance_id", None)
+            data_source = row["data_source"]
+            if iid:
+                images.add(get_docker_image_name(iid, data_source))
+        print(f"{split}: {len(df)} rows, {len(images)} unique images so far")
+
+    print(f"\nTotal unique images to pull: {len(images)}")
+
+    # Pull in parallel (docker pull skips already-cached images automatically)
+    succeeded = 0
+    failed = 0
+    failed_images = []
+
+    with ThreadPoolExecutor(max_workers=args.parallel) as executor:
+        futures = {executor.submit(pull_image, img): img for img in sorted(images)}
+        for i, future in enumerate(as_completed(futures), 1):
+            img, success, msg = future.result()
+            if success:
+                succeeded += 1
+                print(f"  [{i}/{len(images)}] OK: {img}")
+            else:
+                failed += 1
+                failed_images.append((img, msg))
+                print(f"  [{i}/{len(images)}] FAILED: {img} ({msg})")
+
+    print(f"\nDone: {succeeded} succeeded, {failed} failed out of {len(images)} total")
+    if failed_images:
+        print("Failed images:")
+        for img, msg in failed_images:
+            print(f"  {img}: {msg}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/run_mini_swe_32B_megatron_fully_async.sh
+++ b/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/run_mini_swe_32B_megatron_fully_async.sh
@@ -1,0 +1,130 @@
+set -x
+
+# Fully async GRPO training+generation for Qwen3-32B on SWE-Bench (SWE-Gym full dataset).
+# Uses Megatron-LM as the training backend with PP=4 across 4 training nodes.
+#
+# 6-node non-colocated layout:
+#   Node 0 (HEAD/Rollout):  128 SWE workers + Docker-in-Docker — NO GPUs
+#   Node 1 (Inference):     4 vLLM engines × TP=2 = 8 GPUs (DP=4)
+#   Nodes 2-5 (Training):   Megatron TP=4, PP=4, CP=2 = 32 GPUs (DP=1)
+#
+# Fully async: generation and training overlap. Workers loop continuously,
+# staleness manager caps how far generation can get ahead of training.
+#
+# Batch: train_batch_size=128, n_samples=4 → 512 trajectories per training step
+#
+# Usage: bash examples/mini_swe_agent/run_mini_swe_32B_megatron_fully_async.sh [extra_hydra_overrides...]
+
+# Enable NCCL debug logging for cross-node weight sync
+# Redirect NCCL logs to separate directory to avoid flooding main training output
+export NCCL_DEBUG=INFO
+export NCCL_DEBUG_SUBSYS=INIT,COLL
+mkdir -p /scratch/nccl_logs
+export NCCL_DEBUG_FILE=/scratch/nccl_logs/nccl_%h_%p.log
+
+# Reduce PyTorch CUDA memory fragmentation
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+
+# Dynamic OPENAI_BASE_URL for multi-node setup: HEAD_NODE passed from sbatch/launch script
+export OPENAI_BASE_URL="http://${HEAD_NODE:-127.0.0.1}:8001/v1"
+
+DATA_DIR="$HOME/data/swe_gym"
+CKPT_PATH="$HOME/ckpts/llm_mini_swe_32b_megatron"
+
+# Save trajectories here for debugging
+MINISWE_TRAJ_DIR="$HOME/mini_swe_agent_trajs"
+
+# --- Inference layout (Rollout Node) ---
+# 4 engines × TP=2 = 8 GPUs (DP=4)
+NUM_INFERENCE_ENGINES=4
+INFERENCE_TP_SIZE=2
+
+# --- Training layout (4 Training Nodes) ---
+# Megatron: TP=4, PP=4, CP=2 → DP = 32/(4*4*2) = 1
+POLICY_NUM_GPUS=8
+REF_NUM_GPUS=8
+NNODES=4
+MEGATRON_TP=4
+MEGATRON_PP=4
+MEGATRON_CP=2
+
+# Gradient checkpointing (Megatron transformer_config_kwargs)
+RECOMPUTE_GRANULARITY="full"
+RECOMPUTE_METHOD="uniform"
+RECOMPUTE_NUM_LAYERS=1
+
+LOGGER=wandb
+
+# Fully async parameters
+MAX_STALENESS_STEPS=10
+NUM_PARALLEL_GENERATION_WORKERS=128
+MINI_BATCH_SIZE=128
+
+# NOTE: Container must have CPATH set pointing to nvidia-cudnn and nvidia-nccl headers
+# from the pre-built venv, so Ray workers' uv sync can build transformer-engine-torch.
+# See sbatch_32b_megatron_async.sh for the docker run -e CPATH=... flags.
+uv run --extra mcore --extra miniswe --env-file examples/mini_swe_agent/.env.miniswe \
+  -m examples.mini_swe_agent.main_mini_swe_fully_async \
+  data.train_data="['$DATA_DIR/train.parquet']" \
+  data.val_data="['$DATA_DIR/validation.parquet']" \
+  trainer.algorithm.advantage_estimator="grpo" \
+  trainer.policy.model.path="Qwen/Qwen3-32B" \
+  trainer.placement.colocate_all=false \
+  trainer.placement.colocate_policy_ref=true \
+  trainer.strategy=megatron \
+  trainer.placement.policy_num_gpus_per_node=$POLICY_NUM_GPUS \
+  trainer.placement.ref_num_gpus_per_node=$REF_NUM_GPUS \
+  trainer.placement.policy_num_nodes=$NNODES \
+  trainer.placement.ref_num_nodes=$NNODES \
+  trainer.policy.megatron_config.tensor_model_parallel_size=$MEGATRON_TP \
+  trainer.policy.megatron_config.pipeline_model_parallel_size=$MEGATRON_PP \
+  trainer.policy.megatron_config.context_parallel_size=$MEGATRON_CP \
+  trainer.ref.megatron_config.tensor_model_parallel_size=$MEGATRON_TP \
+  trainer.ref.megatron_config.pipeline_model_parallel_size=$MEGATRON_PP \
+  trainer.ref.megatron_config.context_parallel_size=$MEGATRON_CP \
+  ++trainer.policy.megatron_config.transformer_config_kwargs.recompute_granularity=$RECOMPUTE_GRANULARITY \
+  ++trainer.policy.megatron_config.transformer_config_kwargs.recompute_method=$RECOMPUTE_METHOD \
+  ++trainer.policy.megatron_config.transformer_config_kwargs.recompute_num_layers=$RECOMPUTE_NUM_LAYERS \
+  trainer.use_sample_packing=true \
+  trainer.flash_attn=true \
+  trainer.gradient_checkpointing=true \
+  generator.num_inference_engines=$NUM_INFERENCE_ENGINES \
+  generator.inference_engine_tensor_parallel_size=$INFERENCE_TP_SIZE \
+  trainer.epochs=20 \
+  trainer.eval_batch_size=50 \
+  trainer.eval_before_train=false \
+  trainer.eval_interval=200 \
+  trainer.update_epochs_per_batch=1 \
+  trainer.train_batch_size=$MINI_BATCH_SIZE \
+  trainer.policy_mini_batch_size=$MINI_BATCH_SIZE \
+  trainer.micro_forward_batch_size_per_gpu=1 \
+  trainer.micro_train_batch_size_per_gpu=1 \
+  trainer.dump_data_batch=true \
+  trainer.ckpt_interval=10 \
+  trainer.max_prompt_length=4096 \
+  generator.sampling_params.max_generate_length=4096 \
+  generator.max_input_length=40960 \
+  generator.max_turns=20 \
+  trainer.policy.optimizer_config.lr=1.0e-6 \
+  trainer.algorithm.use_kl_loss=true \
+  trainer.fully_async.max_staleness_steps=$MAX_STALENESS_STEPS \
+  trainer.fully_async.num_parallel_generation_workers=$NUM_PARALLEL_GENERATION_WORKERS \
+  generator.backend=vllm \
+  generator.run_engines_locally=True \
+  generator.enable_http_endpoint=True \
+  generator.http_endpoint_host='0.0.0.0' \
+  generator.http_endpoint_port=8002 \
+  generator.weight_sync_backend=nccl \
+  generator.async_engine=true \
+  generator.batched=false \
+  generator.n_samples_per_prompt=4 \
+  generator.gpu_memory_utilization=0.85 \
+  trainer.logger="$LOGGER" \
+  trainer.project_name="mini_swe" \
+  trainer.run_name="mini_swe_32B_megatron_async" \
+  trainer.resume_mode=null \
+  trainer.ckpt_path="$CKPT_PATH" \
+  ++trainer.max_training_seq_len=40960 \
+  ++generator.miniswe_config_path="examples/mini_swe_agent/swebench.yaml" \
+  ++generator.miniswe_traj_dir=$MINISWE_TRAJ_DIR \
+  "$@"

--- a/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/swebench.yaml
+++ b/examples/rl_training/SkyRL/skyrl-train/examples/mini_swe_agent/swebench.yaml
@@ -215,7 +215,7 @@ agent:
 environment:
   cwd: "/testbed"
   timeout: 180
-  pull_timeout: 1200
+  pull_timeout: 3600
   env:
     PAGER: cat
     MANPAGER: cat

--- a/examples/rl_training/SkyRL/skyrl-train/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/examples/rl_training/SkyRL/skyrl-train/skyrl_train/distributed/megatron/megatron_utils.py
@@ -400,6 +400,10 @@ def preprocess_packed_seqs(
             start_idx = cu_seqlens_padded_cpu[i] // cp_size
             # split to 2 chunks
             d = input_ids[i, attention_mask[i]]
+            # Pad d to seqlen_padded_i for CP splitting (d may be shorter
+            # than padded length when sequences are very short, e.g. dummies)
+            if d.shape[0] < seqlen_padded_i:
+                d = torch.nn.functional.pad(d, (0, seqlen_padded_i - d.shape[0]), value=0)
             input_ids_rmpad[start_idx : start_idx + half_seqlen] = d[
                 half_seqlen * cp_rank : half_seqlen * (cp_rank + 1)
             ]

--- a/examples/rl_training/SkyRL/skyrl-train/skyrl_train/env_vars.py
+++ b/examples/rl_training/SkyRL/skyrl-train/skyrl_train/env_vars.py
@@ -86,3 +86,22 @@ Set `_SKYRL_USE_NEW_INFERENCE=1` to enable the new inference layer.
 This flag is intended for internal testing and will be removed once the new
 inference layer is validated and made the default.
 """
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Generation Timeouts
+# ─────────────────────────────────────────────────────────────────────────────
+
+SKYRL_GENERATION_TASK_TIMEOUT_S = int(os.environ.get("SKYRL_GENERATION_TASK_TIMEOUT_S", 3600))
+"""
+Timeout in seconds for a single trajectory generation task (Ray remote call).
+If a task exceeds this, it is cancelled and replaced with a dummy output.
+Prevents deadlocks when Ray ObjectRef result delivery fails under load.
+Default: 3600 (1 hour).
+"""
+
+SKYRL_GENERATION_BATCH_TIMEOUT_S = int(os.environ.get("SKYRL_GENERATION_BATCH_TIMEOUT_S", 7200))
+"""
+Timeout in seconds for the entire batch of generation tasks in generate().
+Safety net if individual task timeouts fail to fire.
+Default: 7200 (2 hours).
+"""

--- a/examples/rl_training/SkyRL/skyrl-train/skyrl_train/fully_async_trainer.py
+++ b/examples/rl_training/SkyRL/skyrl-train/skyrl_train/fully_async_trainer.py
@@ -22,15 +22,40 @@ from tqdm import tqdm
 from skyrl_train.utils import Timer
 from skyrl_train.utils.ppo_utils import normalize_advantages_dict
 from skyrl_train.training_batch import TrainingInputBatch
-from skyrl_train.generators.base import GeneratorOutput
+from skyrl_train.generators.base import GeneratorOutput, GeneratorInput
 from skyrl_train.utils.trainer_utils import ResumeMode, build_dataloader
 from skyrl_train.utils.io import io
-from skyrl_train.generators.utils import prepare_generator_input, concatenate_generator_outputs
+from skyrl_train.generators.utils import (
+    prepare_generator_input,
+    concatenate_generator_outputs,
+    get_rollout_metrics,
+)
 from skyrl_train.inference_engines.utils import get_sampling_params_for_backend
 from dataclasses import dataclass
 from torchdata.stateful_dataloader import StatefulDataLoader
 from typing import List, Tuple, Iterable, Set
 import inspect
+
+
+async def _await_uncancellable(coro):
+    """Await a coroutine to completion even if the current task is cancelled.
+
+    This is used to keep staleness-manager accounting consistent (e.g. decrementing `running`)
+    so cancellations don't leak capacity slots.
+    """
+    task = asyncio.create_task(coro)
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # Temporarily clear cancellation so we can wait for `task` to finish, then re-raise.
+        current = asyncio.current_task()
+        if current is not None:
+            while current.cancelling():
+                current.uncancel()
+        try:
+            return await asyncio.shield(task)
+        finally:
+            raise
 
 
 @dataclass
@@ -144,6 +169,20 @@ class _AsyncStalenessManager:
                 f"Got {self._stat.submitted} != {self._stat.accepted}."
             )
 
+    async def reset_state_for_next_epoch(self, global_step: int) -> None:
+        """Reset internal counters to a consistent state for the next epoch.
+
+        This is a best-effort recovery path to keep training going in the presence of
+        unexpected generation failures. Prefer fixing the underlying cause instead.
+        """
+        async with self._cond:
+            self._current_global_step = int(global_step)
+            self._stat.running = 0
+            consumed = (global_step - 1) * self.mini_batch_size
+            self._stat.accepted = consumed
+            self._stat.submitted = consumed
+            self._cond.notify_all()
+
     def _compute_capacity_unlocked(self) -> int:
         # NOTE(Charlie): do not need a self._current_global_step + 1 here unlike AReal because our
         # `_current_global_step` is "the version being worked on", not already finished steps.
@@ -175,8 +214,9 @@ class _AsyncStalenessManager:
         """
         Called when a generation is not accepted, or generation worker runs into error while generating a trajectory.
 
-        Currently, we do not call this method but instead raise errors. We might need to use this when we want to
-        filter out trajectories.
+        This is used to release capacity when a worker is cancelled mid-generation or when a rollout
+        cannot be enqueued. In these cases we keep training going by emitting dummy rollouts, but
+        still need to maintain `running` accounting.
         """
         async with self._cond:
             self._stat.running -= 1
@@ -248,7 +288,9 @@ class _AsyncDataloader:
         assert self._lock is not None, "Dataloader not initialized; call reset() first"
         async with self._lock:
             for uid in uids:
-                assert uid not in self._consumed_data_uids, "Duplicate UID found in mini-batch"
+                if uid in self._consumed_data_uids:
+                    logger.warning(f"Duplicate UID {uid} in mini-batch (likely from dummy outputs). Skipping.")
+                    continue
                 self._consumed_data_uids.add(uid)
 
     def get_consumed_uids_list(self) -> List[str]:
@@ -394,29 +436,77 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                         # else this loop will never exit.
                         while len(cur_generation_group_mini_batch) < self.mini_batch_size:
                             # We do finish-time FIFO here (not schedule-time FIFO)
-                            cur_generation_group_mini_batch.append(await generation_output_group_buffer.get())
+                            try:
+                                item = await asyncio.wait_for(
+                                    generation_output_group_buffer.get(), timeout=600
+                                )
+                                cur_generation_group_mini_batch.append(item)
+                            except asyncio.TimeoutError:
+                                alive = sum(1 for t in generator_tasks if not t.done())
+                                qsize = generation_output_group_buffer.qsize()
+                                have = len(cur_generation_group_mini_batch)
+                                logger.warning(
+                                    f"buffer.get() timed out after 600s at step {self.global_step}. "
+                                    f"Have {have}/{self.mini_batch_size} items, "
+                                    f"buffer qsize={qsize}, alive generators={alive}/{len(generator_tasks)}"
+                                )
+                                if alive == 0 and qsize == 0:
+                                    # With per-group dummy-filling, this should never happen. If it does,
+                                    # we are in an unrecoverable state (we don't know which UID is missing).
+                                    raise RuntimeError(
+                                        "Generation buffer starvation: all generator tasks finished but the "
+                                        f"buffer only produced {have}/{self.mini_batch_size} items at "
+                                        f"step={self.global_step}."
+                                    )
+                                # else: some generators still alive, keep waiting
+                                continue
                             buffer_pbar.update(1)
                             buffer_pbar.set_postfix({"buffer qsize": generation_output_group_buffer.qsize()})
                         buffer_pbar.close()
 
                     # 2. Post-process the generated groups, aggregating to a single GeneratorOutput, and convert to training format.
-                    with Timer("convert_to_training_input", self.all_timings):
-                        training_input = await asyncio.to_thread(
-                            self.convert_generation_group_mini_batch_to_training_input, cur_generation_group_mini_batch
-                        )
-
                     # 3. Run training and update consumed UIDs.
-                    with Timer("run_training", self.all_timings):
-                        status = await self._run_training(training_input)
+                    # 4. After training: pause generation, sync weights, resume.
+                    try:
+                        with Timer("convert_to_training_input", self.all_timings):
+                            training_input = await asyncio.to_thread(
+                                self.convert_generation_group_mini_batch_to_training_input,
+                                cur_generation_group_mini_batch,
+                            )
+
+                        with Timer("run_training", self.all_timings):
+                            if float(training_input["loss_mask"].sum().item()) == 0.0:
+                                logger.warning(
+                                    f"Step {self.global_step}: all trajectories are loss-masked (likely all dummy). "
+                                    "Skipping training update."
+                                )
+                                status = {"skipped": "all_loss_masked"}
+                            else:
+                                status = await self._run_training(training_input)
+                            await self.async_train_dataloader.mark_consumed_uids(
+                                [g.uid for g in cur_generation_group_mini_batch]
+                            )
+
+                        with Timer("sync_weights", self.all_timings):
+                            if "skipped" not in status:
+                                await self.inference_engine_client.pause_generation()
+                                await self.async_sync_policy_weights_to_inference_engines()
+                                await self.inference_engine_client.resume_generation()
+                            else:
+                                logger.info(
+                                    f"Step {self.global_step}: skipping weight sync because training was skipped."
+                                )
+                    except Exception as e:
+                        logger.error(f"Step {self.global_step} FAILED: {e}")
+                        logger.error(traceback.format_exc())
+                        import sys
+
+                        traceback.print_exc(file=sys.stderr)
+                        status = {"error": str(e)}
+                        # Mark UIDs consumed so we don't retry same data
                         await self.async_train_dataloader.mark_consumed_uids(
                             [g.uid for g in cur_generation_group_mini_batch]
                         )
-
-                    # 4. After training: pause generation, sync weights, resume.
-                    with Timer("sync_weights", self.all_timings):
-                        await self.inference_engine_client.pause_generation()
-                        await self.async_sync_policy_weights_to_inference_engines()
-                        await self.inference_engine_client.resume_generation()
 
                 # 5. Set logs for this training step.
                 logger.info(status)
@@ -452,10 +542,13 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                     steps_completed_in_epoch = self.num_steps_per_epoch
                 expected_consumed_in_epoch = self.mini_batch_size * steps_completed_in_epoch
                 actual_consumed_in_epoch = len(self.async_train_dataloader.get_consumed_uids_list())
-                assert actual_consumed_in_epoch == expected_consumed_in_epoch, (
-                    "Unexpected number of consumed data UIDs. Got: "
-                    f"{actual_consumed_in_epoch} != {expected_consumed_in_epoch}"
-                )
+                if actual_consumed_in_epoch != expected_consumed_in_epoch:
+                    logger.warning(
+                        f"Consumed UIDs mismatch at step {self.global_step - 1}: "
+                        f"actual={actual_consumed_in_epoch} != expected={expected_consumed_in_epoch} "
+                        f"(delta={expected_consumed_in_epoch - actual_consumed_in_epoch}). "
+                        f"This can happen when buffer items are lost due to worker errors or timeouts."
+                    )
 
             # 8. Per-epoch epilogue.
             if self.cfg.trainer.update_ref_every_epoch and self.ref_model is not None:
@@ -474,11 +567,24 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
             assert all(
                 t.done() for t in generator_tasks
             ), "Generator tasks must be done before resetting the dataloader manager and validating the staleness manager."
-            assert (
-                generation_output_group_buffer.qsize() == 0
-            ), f"We expect all generation output to be consumed by the training worker at end of an epoch, got {generation_output_group_buffer.qsize()}."
+            remaining_qsize = generation_output_group_buffer.qsize()
+            if remaining_qsize > 0:
+                logger.warning(
+                    f"Epoch end: buffer has {remaining_qsize} unconsumed items (expected 0). "
+                    f"Draining to prevent stale data in next epoch."
+                )
+                while not generation_output_group_buffer.empty():
+                    generation_output_group_buffer.get_nowait()
             await self.async_train_dataloader.reset_at_epoch_end()
-            await self._staleness_manager.validate_state_at_epoch_end(self.global_step)
+            try:
+                await self._staleness_manager.validate_state_at_epoch_end(self.global_step)
+            except AssertionError as e:
+                logger.warning(
+                    f"Staleness manager validation failed at epoch end (non-fatal): {e}. "
+                    f"This can happen when buffer items are lost due to worker errors. "
+                    f"Resetting staleness manager state for next epoch."
+                )
+                await self._staleness_manager.reset_state_for_next_epoch(self.global_step)
 
             # End of an epoch.
         pbar.close()
@@ -537,60 +643,124 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 if rand_prompts is None:
                     return
 
-                # 1. Prepare generator input
                 assert len(rand_prompts) == 1
-                generator_input, uids = prepare_generator_input(
-                    rand_prompts,
-                    self.cfg.generator.n_samples_per_prompt,
-                    get_sampling_params_for_backend(self.cfg.generator.backend, self.cfg.generator.sampling_params),
-                    self.cfg.environment.env_class,
-                    "train",
-                    self.global_step,
-                )
-                assert all(uid == uids[0] for uid in uids), "Expect all uids to be the same"
+                uid = rand_prompts[0]["uid"]
 
-                # 2. Acquire capacity slot.
+                # 1. Acquire capacity slot early so we never "lose" a scheduled UID without accounting.
                 slot_acquired = False
                 await self._staleness_manager.acquire_submission_slot()
                 slot_acquired = True
 
-                # 3. Generate one rollout group
+                # 2. Generate one rollout group
                 global_step_at_start = self.global_step  # for staleness control
-
-                if "disable_tqdm" in inspect.signature(self.generator.generate).parameters:
-                    # A workaround to disable tqdm for the SkyRLGymGenerator.generate method which will
-                    # blast the console with each worker's progress bar.
-                    cur_generator_output: GeneratorOutput = await self.generator.generate(
-                        generator_input, disable_tqdm=True
+                group_size = self.cfg.generator.n_samples_per_prompt
+                generator_input = None
+                try:
+                    generator_input, uids = prepare_generator_input(
+                        rand_prompts,
+                        group_size,
+                        get_sampling_params_for_backend(
+                            self.cfg.generator.backend, self.cfg.generator.sampling_params
+                        ),
+                        self.cfg.environment.env_class,
+                        "train",
+                        self.global_step,
                     )
-                else:
-                    cur_generator_output: GeneratorOutput = await self.generator.generate(generator_input)
+                    assert all(u == uids[0] for u in uids), "Expect all uids to be the same"
 
-                # 4. Enqueue the completed group and mark accepted to free capacity slot.
+                    if "disable_tqdm" in inspect.signature(self.generator.generate).parameters:
+                        # A workaround to disable tqdm for the SkyRLGymGenerator.generate method which will
+                        # blast the console with each worker's progress bar.
+                        cur_generator_output: GeneratorOutput = await self.generator.generate(
+                            generator_input, disable_tqdm=True
+                        )
+                    else:
+                        cur_generator_output: GeneratorOutput = await self.generator.generate(generator_input)
+                except asyncio.CancelledError:
+                    # Ensure we release the slot on cancellation to avoid leaking running-count.
+                    if slot_acquired:
+                        await _await_uncancellable(self._staleness_manager.on_rollout_rejected())
+                    raise
+                except Exception as e:
+                    # Never drop a scheduled UID on the floor: enqueue a valid dummy output so the
+                    # consumer can keep making progress and we maintain submitted==accepted invariants.
+                    logger.error(f"Generator worker exception for uid={uid}: {e}")
+                    logger.error(f"Traceback: \n{traceback.format_exc()}")
+                    cur_generator_output = self._make_dummy_generator_output(
+                        group_size=group_size,
+                        stop_reason="generator_error",
+                        generator_input=generator_input,
+                    )
+                    uids = [uid] * group_size
+
+                # 3. Enqueue the completed group and mark accepted to free capacity slot.
+                logger.debug(
+                    f"Worker uid={uid} generate() returned, enqueueing to buffer "
+                    f"(qsize={generation_output_group_buffer.qsize()}, step={global_step_at_start})"
+                )
                 try:
                     generation_output_group_buffer.put_nowait(
                         GeneratedOutputGroup(
                             generator_output=cur_generator_output,
-                            uid=uids[0],
+                            uid=uid,
                             global_step_when_scheduled=global_step_at_start,
                         )
                     )
                 except asyncio.QueueFull:
                     raise AssertionError("Generation buffer should never be full given staleness control.")
-                await self._staleness_manager.on_rollout_accepted()
+                logger.debug(
+                    f"Worker uid={uid} enqueued successfully "
+                    f"(qsize={generation_output_group_buffer.qsize()})"
+                )
+                await _await_uncancellable(self._staleness_manager.on_rollout_accepted())
         except asyncio.CancelledError:
-            # If a slot was acquired but we exit early, release running count
-            try:
-                if "slot_acquired" in locals() and slot_acquired:
-                    raise RuntimeError("Generation workers should only be cancelled when they finish running.")
-            finally:
-                return
+            return
         except Exception as e:
             logger.error(f"Generator worker errored out with exception: {e}")
             logger.error(f"Traceback: \n{traceback.format_exc()}")
-            if "slot_acquired" in locals() and slot_acquired:
-                raise RuntimeError("Generation workers should only run into error when they finish running.")
-            sys.exit(1)
+            # This should be unreachable because we handle exceptions per-iteration. If it does happen,
+            # keep the process alive (trainer will likely surface the error via timeouts/metrics).
+            return
+
+    def _make_dummy_generator_output(
+        self,
+        *,
+        group_size: int,
+        stop_reason: str,
+        generator_input: GeneratorInput | None,
+    ) -> GeneratorOutput:
+        eos_token_id = getattr(self.tokenizer, "eos_token_id", None)
+        if eos_token_id is None:
+            eos_token_id = 0
+
+        response_ids = [[int(eos_token_id)] for _ in range(group_size)]
+        prompt_token_ids = [[int(eos_token_id)] for _ in range(group_size)]
+        loss_masks = [[0] for _ in range(group_size)]
+        rewards = [0.0 for _ in range(group_size)]
+        stop_reasons = [stop_reason for _ in range(group_size)]
+
+        rollout_logprobs = None
+        if getattr(self.cfg.generator.sampling_params, "logprobs", 0) not in (None, 0):
+            rollout_logprobs = [[0.0] for _ in range(group_size)]
+
+        rollout_metrics = get_rollout_metrics(response_ids, rewards)
+
+        out: GeneratorOutput = {
+            "prompt_token_ids": prompt_token_ids,
+            "response_ids": response_ids,
+            "rewards": rewards,
+            "loss_masks": loss_masks,
+            "stop_reasons": stop_reasons,
+            "rollout_metrics": rollout_metrics,
+            "rollout_logprobs": rollout_logprobs,
+        }
+
+        if generator_input is not None and generator_input.get("trajectory_ids", None) is not None:
+            out["trajectory_ids"] = generator_input["trajectory_ids"]
+        if self.cfg.generator.step_wise_trajectories:
+            out["is_last_step"] = [True for _ in range(group_size)]
+
+        return out
 
     async def async_sync_policy_weights_to_inference_engines(self):
         return await self.policy_model.async_run_method(
@@ -628,6 +798,19 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         assert generator_output["rollout_metrics"] is not None, "Rollout metrics should be non-null."
         self.all_metrics.update(generator_output["rollout_metrics"])
 
+        # Count dummy vs real trajectories (dummies have single-token response)
+        all_response_ids = sum([output["response_ids"] for output in generator_outputs], [])
+        num_dummy = sum(1 for r in all_response_ids if len(r) <= 2)
+        num_real = len(all_response_ids) - num_dummy
+        logger.info(f"Training batch: {num_real} real, {num_dummy} dummy out of {len(all_response_ids)} total")
+        self.all_metrics.update(
+            {
+                "async/num_real_trajectories": num_real,
+                "async/num_dummy_trajectories": num_dummy,
+                "async/dummy_ratio": num_dummy / max(len(all_response_ids), 1),
+            }
+        )
+
         # Log staleness statistics for this step
         self.all_metrics.update(
             {
@@ -646,7 +829,10 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         vis = self.tokenizer.decode(generator_output["response_ids"][0])
         logger.info(f"Example generated: {vis}")
 
-        return self.convert_to_training_input(generator_output, uids)
+        training_input = self.convert_to_training_input(generator_output, uids)
+        training_input.metadata["num_real_trajectories"] = num_real
+        training_input.metadata["num_dummy_trajectories"] = num_dummy
+        return training_input
 
     def save_checkpoints(self):
         """

--- a/examples/rl_training/SkyRL/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/examples/rl_training/SkyRL/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -446,6 +446,20 @@ class InferenceEngineClient(InferenceEngineInterface):
         # Always use the retry loop which also issues the first request inside
         return await self._chat_completion_with_retry(engine_idx, request_payload)
 
+    async def engine_chat_completion(self, engine_idx: int, request_payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Route chat completion to a specific engine (for per-engine routing).
+
+        Same as chat_completion() but bypasses _select_engine_idx() and routes directly
+        to the given engine. Used by per-engine HTTP routes (/engines/{id}/v1/chat/completions)
+        so that an external router (e.g. ThunderAgent) can pin requests to specific engines
+        for better prefix cache locality.
+        """
+        if engine_idx < 0 or engine_idx >= len(self.engines):
+            raise ValueError(f"engine_idx {engine_idx} out of range [0, {len(self.engines)})")
+        # Remove session_id if present — caller already chose the engine explicitly
+        request_payload["json"].pop("session_id", None)
+        return await self._chat_completion_with_retry(engine_idx, request_payload)
+
     async def completion(self, request_payload: Dict[str, Any]) -> Dict[str, Any]:
         """
         Handles an OpenAI /completions request.

--- a/examples/rl_training/SkyRL/skyrl-train/skyrl_train/inference_engines/inference_engine_client_http_endpoint.py
+++ b/examples/rl_training/SkyRL/skyrl-train/skyrl_train/inference_engines/inference_engine_client_http_endpoint.py
@@ -326,6 +326,131 @@ def create_app() -> fastapi.FastAPI:
                 all_engine_metrics.append({"engine_id": i, "error": str(e)})
         return {"timestamp": time.time(), "engines": all_engine_metrics}
 
+    # ------------------------------------------------------------------
+    # Per-engine routes: /engines/{engine_id}/...
+    # These allow an external router (e.g. ThunderAgent) to pin requests
+    # to a specific vLLM engine for better prefix cache locality.
+    # ------------------------------------------------------------------
+
+    def _validate_engine_id(engine_id: int) -> Optional[JSONResponse]:
+        """Return an error JSONResponse if engine_id is out of range, else None."""
+        if _global_inference_engine_client is None:
+            return JSONResponse(
+                content=ErrorResponse(
+                    error=ErrorInfo(
+                        message="Inference engine client not initialized",
+                        type=HTTPStatus.SERVICE_UNAVAILABLE.phrase,
+                        code=HTTPStatus.SERVICE_UNAVAILABLE.value,
+                    )
+                ).model_dump(),
+                status_code=HTTPStatus.SERVICE_UNAVAILABLE.value,
+            )
+        num_engines = len(_global_inference_engine_client.engines)
+        if engine_id < 0 or engine_id >= num_engines:
+            return JSONResponse(
+                content=ErrorResponse(
+                    error=ErrorInfo(
+                        message=f"engine_id {engine_id} out of range [0, {num_engines})",
+                        type=HTTPStatus.BAD_REQUEST.phrase,
+                        code=HTTPStatus.BAD_REQUEST.value,
+                    )
+                ).model_dump(),
+                status_code=HTTPStatus.BAD_REQUEST.value,
+            )
+        return None
+
+    @app.post("/engines/{engine_id}/v1/chat/completions")
+    async def engine_chat_completion(engine_id: int, raw_request: Request):
+        """Route a chat completion request to a specific engine by index.
+
+        Bypasses session_id-based routing so that an external router can
+        pin requests to individual engines for prefix cache locality.
+        """
+        error = _validate_engine_id(engine_id)
+        if error is not None:
+            return error
+
+        try:
+            request_json = await raw_request.json()
+
+            validation_error = _validate_openai_request(request_json, endpoint="/chat/completions")
+            if validation_error is not None:
+                return JSONResponse(content=validation_error.model_dump(), status_code=validation_error.error.code)
+
+            payload = {
+                "json": request_json,
+                "headers": dict(raw_request.headers) if hasattr(raw_request, "headers") else {},
+            }
+            response = await _global_inference_engine_client.engine_chat_completion(engine_id, payload)
+
+            if "error" in response or response.get("object", "") == "error":
+                error_code = response["error"]["code"] if "error" in response else response["code"]
+                return JSONResponse(content=response, status_code=error_code)
+            return JSONResponse(content=response)
+
+        except json.JSONDecodeError as e:
+            error_response = ErrorResponse(
+                error=ErrorInfo(
+                    message=f"Invalid JSON error: {str(e)}",
+                    type=HTTPStatus.BAD_REQUEST.phrase,
+                    code=HTTPStatus.BAD_REQUEST.value,
+                )
+            )
+            return JSONResponse(content=error_response.model_dump(), status_code=HTTPStatus.BAD_REQUEST.value)
+        except Exception as e:
+            tb = traceback.format_exc()
+            logger.error(f"Error handling /engines/{engine_id}/v1/chat/completions:\n{tb}")
+            error_response = ErrorResponse(
+                error=ErrorInfo(
+                    message=f"Error handling /engines/{engine_id}/v1/chat/completions: {str(e)}",
+                    type=HTTPStatus.INTERNAL_SERVER_ERROR.phrase,
+                    code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+                )
+            )
+            return JSONResponse(content=error_response.model_dump(), status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value)
+
+    @app.get("/engines/{engine_id}/metrics")
+    async def get_engine_metrics(engine_id: int):
+        """Return metrics for a single engine.
+
+        Same format as /metrics but the ``engines`` array contains only the
+        requested engine, which is what SkyRLMetricsClient expects.
+        """
+        error = _validate_engine_id(engine_id)
+        if error is not None:
+            return error
+
+        engine = _global_inference_engine_client.engines[engine_id]
+        try:
+            metrics = await engine.get_engine_metrics()
+            engine_metrics = {"engine_id": engine_id, **metrics}
+        except Exception as e:
+            engine_metrics = {"engine_id": engine_id, "error": str(e)}
+        return {"timestamp": time.time(), "engines": [engine_metrics]}
+
+    @app.get("/engines/{engine_id}/v1/models")
+    async def engine_list_models(engine_id: int):
+        """Return the model list for a specific engine.
+
+        All engines serve the same model, so this returns the same result
+        as a global /v1/models endpoint would.  ThunderAgent calls this to
+        verify the backend is healthy.
+        """
+        error = _validate_engine_id(engine_id)
+        if error is not None:
+            return error
+
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": _global_inference_engine_client.model_name,
+                    "object": "model",
+                    "owned_by": "skyrl",
+                }
+            ],
+        }
+
     # This handler only catches unexpected server-side exceptions
     @app.exception_handler(Exception)
     async def general_exception_handler(request: Request, exc: Exception):

--- a/examples/rl_training/SkyRL/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/examples/rl_training/SkyRL/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -159,7 +159,7 @@ def create_ray_wrapped_inference_engines(
     if not use_hybrid_engine:
         # Create a big placement group to ensure that all inference engines are packed
         bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_inference_engines * per_engine_gpu_count)]
-        shared_pg = placement_group(bundles, strategy="PACK")
+        shared_pg = placement_group(bundles, strategy="STRICT_PACK")
         get_ray_pg_ready_with_timeout(shared_pg, timeout=SKYRL_RAY_PG_TIMEOUT_IN_S)
 
     for i in range(num_inference_engines):

--- a/examples/rl_training/SkyRL/skyrl-train/skyrl_train/model_wrapper.py
+++ b/examples/rl_training/SkyRL/skyrl-train/skyrl_train/model_wrapper.py
@@ -4,11 +4,16 @@
 # https://github.com/OpenRLHF/OpenRLHF/blob/main/openrlhf/models/model.py
 
 from typing import Any, Dict, Optional, Tuple, Union
+import os
+import random
+import time
 import torch
 import torch.nn as nn
+from filelock import FileLock
 from loguru import logger
 from peft import LoraConfig, TaskType, get_peft_model
 from peft.tuners.lora import LoraLayer
+import safetensors
 import transformers
 from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, BitsAndBytesConfig
 import numpy as np
@@ -16,6 +21,34 @@ from skyrl_train.distributed.ulysses.utils import ulysses_pad_and_slice_inputs, 
 from skyrl_train.utils.torch_utils import chunked_entropy_from_logits, logprobs_from_logits
 from flash_attn.bert_padding import pad_input, unpad_input
 from packaging.version import Version
+
+
+# Monkey-patch safetensors.safe_open with retry logic.
+# When multiple workers simultaneously mmap the same safetensors files,
+# safe_open can fail with "SafetensorError: EOF while parsing" due to
+# kernel returning zero-filled pages. Retrying with backoff resolves this.
+_original_safe_open = safetensors.safe_open
+
+
+def _safe_open_with_retry(*args, **kwargs):
+    max_retries = 5
+    for attempt in range(max_retries):
+        try:
+            return _original_safe_open(*args, **kwargs)
+        except safetensors.SafetensorError as e:
+            if "EOF while parsing" in str(e) and attempt < max_retries - 1:
+                wait = random.uniform(0.5, 2.0) * (attempt + 1)
+                logger.warning(f"safe_open failed (attempt {attempt + 1}/{max_retries}), retrying in {wait:.1f}s: {e}")
+                time.sleep(wait)
+            else:
+                raise
+
+
+safetensors.safe_open = _safe_open_with_retry
+# Also patch the already-imported reference in transformers (uses `from safetensors import safe_open`)
+import transformers.modeling_utils
+
+transformers.modeling_utils.safe_open = _safe_open_with_retry
 
 
 class HFModelWrapper(nn.Module):
@@ -103,16 +136,22 @@ class HFModelWrapper(nn.Module):
             if rope_theta:
                 rope_scaling_kwargs["rope_theta"] = rope_theta
 
-            self.model = model_class.from_pretrained(
-                pretrain_or_model,
-                config=model_config,
-                trust_remote_code=True,
-                attn_implementation=self.attn_implementation,
-                quantization_config=nf4_config,
-                torch_dtype=torch.bfloat16 if bf16 else torch.float32,
-                device_map=device_map,
-                **rope_scaling_kwargs,
-            )
+            # Serialize model loading to prevent concurrent safetensors mmap race.
+            # When 16+ workers simultaneously mmap the same .safetensors files,
+            # safe_open() can get zero-filled pages → SafetensorError: EOF.
+            _lock_dir = os.environ.get("HOME", "/tmp")
+            _lock_path = os.path.join(_lock_dir, ".safetensors_load.lock")
+            with FileLock(_lock_path, timeout=1800):
+                self.model = model_class.from_pretrained(
+                    pretrain_or_model,
+                    config=model_config,
+                    trust_remote_code=True,
+                    attn_implementation=self.attn_implementation,
+                    quantization_config=nf4_config,
+                    torch_dtype=torch.bfloat16 if bf16 else torch.float32,
+                    device_map=device_map,
+                    **rope_scaling_kwargs,
+                )
 
             # gpt oss
             if Version(transformers.__version__) >= Version("4.56.2"):

--- a/examples/rl_training/SkyRL/skyrl-train/skyrl_train/trainer.py
+++ b/examples/rl_training/SkyRL/skyrl-train/skyrl_train/trainer.py
@@ -1095,13 +1095,30 @@ class RayPPOTrainer:
                 start_idx = local_step * mini_batch_size
                 end_idx = (local_step + 1) * mini_batch_size
 
+                import time as _time
+                _t0 = _time.time()
                 # Workers fetch from object store and slice locally
                 status = self.dispatch.forward_backward_from_staged(model, data_ref, start_idx, end_idx)
+                _fwd_bwd_time = _time.time() - _t0
                 for k, v in status.items():
                     all_metrics[k].append(v)
 
                 # Optimizer step after each mini batch
+                _t1 = _time.time()
                 grad_norm = self.dispatch.optim_step(model)
+                _optim_time = _time.time() - _t1
+                traj_info = ""
+                if "num_real_trajectories" in data.metadata:
+                    nr = data.metadata["num_real_trajectories"]
+                    nd = data.metadata["num_dummy_trajectories"]
+                    traj_info = f", trajectories={nr}real/{nd}dummy"
+                logger.info(
+                    f"{model}_train mini-batch {local_step+1}/{num_mini_batches} "
+                    f"(epoch {_epoch+1}/{self.cfg.trainer.update_epochs_per_batch}): "
+                    f"fwd_bwd={_fwd_bwd_time:.1f}s, optim_step={_optim_time:.1f}s"
+                    + (f", grad_norm={grad_norm:.4f}" if grad_norm is not None else "")
+                    + traj_info
+                )
                 if grad_norm is not None:
                     all_metrics["grad_norm"].append(grad_norm)
 

--- a/examples/rl_training/SkyRL/skyrl-train/skyrl_train/utils/utils.py
+++ b/examples/rl_training/SkyRL/skyrl-train/skyrl_train/utils/utils.py
@@ -669,6 +669,13 @@ def prepare_runtime_environment(cfg: Union[SkyRLConfig, DictConfig]) -> dict[str
         logger.info(f"Exporting HF_HOME to ray runtime env: {os.environ['HF_HOME']}")
         env_vars["HF_HOME"] = os.environ["HF_HOME"]
 
+    # NOTE: Export HF_TOKEN for HuggingFace authentication (needed by FSDP workers loading model weights)
+    if os.environ.get("HF_TOKEN"):
+        env_vars["HF_TOKEN"] = os.environ["HF_TOKEN"]
+
+    if os.environ.get("HUGGINGFACE_HUB_CACHE"):
+        env_vars["HUGGINGFACE_HUB_CACHE"] = os.environ["HUGGINGFACE_HUB_CACHE"]
+
     # NOTE: Export XDG_CACHE_HOME for vLLM and other tools
     if os.environ.get("XDG_CACHE_HOME"):
         logger.info(f"Exporting XDG_CACHE_HOME to ray runtime env: {os.environ['XDG_CACHE_HOME']}")
@@ -694,11 +701,27 @@ def prepare_runtime_environment(cfg: Union[SkyRLConfig, DictConfig]) -> dict[str
         logger.info(f"Exporting SKYRL_WORKER_NCCL_TIMEOUT_IN_S to ray runtime env: {os.environ['SKYRL_WORKER_NCCL_TIMEOUT_IN_S']}")
         env_vars["SKYRL_WORKER_NCCL_TIMEOUT_IN_S"] = os.environ["SKYRL_WORKER_NCCL_TIMEOUT_IN_S"]
 
+    # NOTE: Export TORCH_CUDA_ARCH_LIST for megatron-core import on CPU-only nodes
+    if os.environ.get("TORCH_CUDA_ARCH_LIST"):
+        logger.info(f"Exporting TORCH_CUDA_ARCH_LIST to ray runtime env: {os.environ['TORCH_CUDA_ARCH_LIST']}")
+        env_vars["TORCH_CUDA_ARCH_LIST"] = os.environ["TORCH_CUDA_ARCH_LIST"]
+
     # NOTE: Export NCCL timeout env vars
     for nccl_var in ["NCCL_TIMEOUT", "TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC", "NCCL_ASYNC_ERROR_HANDLING"]:
         if os.environ.get(nccl_var):
             env_vars[nccl_var] = os.environ[nccl_var]
 
+    # NOTE: Export OPENAI_BASE_URL for mini-swe-agent LiteLLM → vLLM HTTP endpoint routing.
+    # Without this, init_and_run Ray tasks on remote nodes can't reach ThunderAgent/vLLM.
+    if os.environ.get("OPENAI_BASE_URL"):
+        logger.info(f"Exporting OPENAI_BASE_URL to ray runtime env: {os.environ['OPENAI_BASE_URL']}")
+        env_vars["OPENAI_BASE_URL"] = os.environ["OPENAI_BASE_URL"]
+
+    # NOTE: Export DOCKER_NODE_RESOURCE so that init_and_run Ray tasks on remote nodes
+    # can see the docker_node resource constraint and schedule on the correct node.
+    if os.environ.get("DOCKER_NODE_RESOURCE"):
+        logger.info("Exporting DOCKER_NODE_RESOURCE to ray runtime env")
+        env_vars["DOCKER_NODE_RESOURCE"] = os.environ["DOCKER_NODE_RESOURCE"]
 
     if SKYRL_LD_LIBRARY_PATH_EXPORT:
         # export `LD_LIBRARY_PATH` to ray runtime env.

--- a/examples/rl_training/SkyRL/skyrl-train/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/examples/rl_training/SkyRL/skyrl-train/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -88,7 +88,7 @@ class MegatronModelWrapper:
                 tp_group=tp_grp,
                 inference_only=True,
                 cp_group=None,  # we handle cp gathering in `postprocess_packed_seqs`
-                chunk_size=None,
+                chunk_size=4096,  # chunk to avoid OOM from full-length float32 logits
             )
             return torch.tensor(0.0, device=token_logprobs.device), {"log_probs": token_logprobs}
 
@@ -233,7 +233,7 @@ class MegatronModelWrapper:
                 tp_group=tp_grp,
                 inference_only=False,
                 cp_group=None,  # we handle cp gathering in `postprocess_packed_seqs`
-                chunk_size=None,
+                chunk_size=4096,  # chunk to avoid OOM from full-length float32 logits
             )
 
             action_log_probs = token_logprobs[:, -num_actions:]

--- a/examples/rl_training/SkyRL/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
+++ b/examples/rl_training/SkyRL/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
@@ -6,10 +6,28 @@ from transformers import AutoTokenizer, AutoConfig
 from huggingface_hub import snapshot_download
 
 import os
+import sys
+import time
+import importlib.metadata as _importlib_metadata
 from datetime import timedelta
 from typing import List, Dict, Any, Optional, Union
 from collections import defaultdict
 from omegaconf import OmegaConf
+
+# Workaround: Wait for UV venv to stabilize before importing transformer-engine.
+# When Ray spawns multiple actors sharing the same UV venv, concurrent `uv sync`
+# can temporarily remove transformer-engine-cu12 during its "Uninstall 1 / Install 1"
+# cycle. TE's sanity_checks_for_pypi_installation() uses importlib.metadata to check
+# for this package, and raises RuntimeError if it's missing. Polling until the package
+# metadata is available ensures we import TE after the sync completes.
+for _te_wait_attempt in range(10):
+    try:
+        _importlib_metadata.distribution("transformer-engine-cu12")
+        break
+    except _importlib_metadata.PackageNotFoundError:
+        if _te_wait_attempt < 9:
+            time.sleep(3)
+        # On last attempt, proceed anyway and let TE's own error propagate
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.peft.lora import LoRA
@@ -197,6 +215,15 @@ class MegatronWorker:
         """
         Initialize the Megatron-Bridge bridge and provider objects + hf_config and tokenizer
         """
+        # Resolve repo ID (e.g. "Qwen/Qwen3-32B") to local snapshot path if cached.
+        # This avoids HFValidationError where transformers' cache resolution passes
+        # local cache paths to huggingface_hub's validate_repo_id().
+        if not os.path.isdir(model_path):
+            try:
+                model_path = snapshot_download(model_path, local_files_only=True)
+            except Exception:
+                pass
+
         tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
         hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
 

--- a/examples/rl_training/SkyRL/submit_32b_megatron_default_vs_tr.sh
+++ b/examples/rl_training/SkyRL/submit_32b_megatron_default_vs_tr.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Submit both 32B Megatron repro jobs (default vs TR router) and print job IDs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+JOB_DEFAULT=$(sbatch --export=ALL --parsable "$SCRIPT_DIR/sbatch_32b_megatron_default.sh")
+JOB_TR=$(sbatch --export=ALL --parsable "$SCRIPT_DIR/sbatch_32b_megatron_tr.sh")
+
+echo "Submitted:"
+echo "  default: $JOB_DEFAULT"
+echo "  tr:      $JOB_TR"


### PR DESCRIPTION
This PR extends the existing ThunderAgent SkyRL example with a 32B Qwen3 fully-async RL example, including: 
- Add a complete 32B training example, including launch orchestration, profiling, and SWE-bench image pre-pull
- Add a 6-node SLURM reproducibility pipeline and separate wrappers for default/TR router
- Update the training/inference integration path for fully-async Megatron workloads (generation loop, inference endpoint/client integration, worker/runtime behavior, and related trainer logic)
- Add docs and setup templates for credentials and cluster-specific configs