### PR TITLE
feat: weight-sync coordination, reusable route bundle, session-id program fallback

### DIFF
--- a/ThunderAgent/__init__.py
+++ b/ThunderAgent/__init__.py
@@ -11,6 +11,7 @@ from .config import Config, get_config, set_config
 from .backend import BackendState
 from .program import ProgramState, ProgramStatus
 from .scheduler import MultiBackendRouter
+from .app import get_program_id, register_routes
 
 __all__ = [
     "Config",
@@ -20,6 +21,8 @@ __all__ = [
     "ProgramState",
     "ProgramStatus",
     "MultiBackendRouter",
+    "get_program_id",
+    "register_routes",
 ]
 
 __version__ = "0.2.0"

--- a/ThunderAgent/app.py
+++ b/ThunderAgent/app.py
@@ -1,26 +1,243 @@
 """ThunderAgent FastAPI application entry point."""
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Mapping, Optional
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from .config import get_config
+from .config import Config, get_config
 from .scheduler import MultiBackendRouter
-from .program import ProgramStatus
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def get_program_id(payload: Dict[str, Any], headers: Optional[Mapping[str, str]] = None) -> str:
+    """Extract program_id from the request.
+
+    Resolution order:
+      1. ``payload["program_id"]``
+      2. ``payload["extra_body"]["program_id"]``
+      3. ``X-Session-ID`` request header (case-insensitive), if ``headers`` is
+         provided. This lets clients that already route by session id (e.g.
+         SkyRL) reuse the session id as the ThunderAgent program id without
+         needing to inject ``program_id`` into the payload.
+      4. ``"default"`` as a last-resort fallback.
+    """
+    if "program_id" in payload:
+        return str(payload["program_id"])
+    extra_body = payload.get("extra_body", {})
+    if isinstance(extra_body, dict) and "program_id" in extra_body:
+        return str(extra_body["program_id"])
+    if headers is not None:
+        session_id = headers.get("X-Session-ID") or headers.get("x-session-id")
+        if session_id:
+            return str(session_id)
+    return "default"
+
+
+def register_routes(app: FastAPI, ta_router: MultiBackendRouter, config: Optional[Config] = None) -> None:
+    """Register all ThunderAgent HTTP routes on the given FastAPI app.
+
+    This is the shared route bundle used by both the standalone ThunderAgent
+    server (see bottom of this module) and external FastAPI apps that embed
+    ThunderAgent (e.g. an RL training framework that wraps the router with
+    its own integration layer).
+
+    Args:
+        app: FastAPI application to register routes on.
+        ta_router: ThunderAgent MultiBackendRouter instance. The caller is
+            responsible for ``await ta_router.start()`` / ``stop()`` on the
+            app lifecycle.
+        config: Optional config override. If None, uses ``get_config()`` at
+            request time.
+    """
+
+    def _get_config() -> Config:
+        return config if config is not None else get_config()
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request):
+        """Handle chat completions request."""
+        try:
+            payload = await request.json()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="Invalid JSON") from exc
+        # Get or create program state (new programs go to waiting queue)
+        program_id = get_program_id(payload, request.headers)
+        program_state = ta_router.get_or_create_program(program_id)
+
+        # Profile: record request arrival BEFORE pause check (for accurate tool_call_time)
+        if program_state.profile:
+            program_state.profile.on_request_arrive()
+
+        # Update state: check capacity, may pause and wait (max 20 min, then force resume)
+        await ta_router.update_program_before_request(program_id, program_state, payload)
+
+        # Profile: record request start AFTER pause (captures pause_time)
+        if program_state.profile:
+            program_state.profile.on_request_start()
+
+        # Resolve backend after any pause/resume to honor migrations.
+        backend = ta_router.get_backend_for_program(program_id)
+
+        # Callback to update state after response
+        async def on_usage(
+            total_tokens: int,
+            prompt_tokens: int | None,
+            completion_tokens: int | None,
+            cached_tokens: int | None,
+        ) -> None:
+            ta_router.update_program_after_request(
+                program_id,
+                program_state,
+                total_tokens,
+                prompt_tokens or 0,
+            )
+            # Profile: record request end with KV cache info
+            if program_state.profile:
+                program_state.profile.on_request_end(
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    cached_tokens=cached_tokens,
+                )
+
+        # Callback for streaming token progress updates (every 20 tokens)
+        def on_token_progress(delta_tokens: int) -> None:
+            ta_router.update_program_tokens_streaming(program_state, delta_tokens)
+
+        # Forward to vLLM (sticky unless rescheduled from the global paused pool)
+        # Pass profile callbacks for token timing
+        return await ta_router.proxy_request(
+            backend, payload,
+            on_usage=on_usage,
+            on_first_token=program_state.profile.on_first_token if program_state.profile else None,
+            on_token=program_state.profile.on_token if program_state.profile else None,
+            on_token_progress=on_token_progress,
+        )
+
+    @app.get("/programs")
+    async def list_programs():
+        """List all programs (includes profile data if profiling enabled)."""
+        result = {}
+        for pid, state in ta_router.programs.items():
+            program_data = {
+                "backend": state.backend_url,
+                "context_len": state.context_len,
+                "total_tokens": state.total_tokens,
+                "step_count": state.step_count,
+                "status": state.status.value,
+                "state": state.state.value,
+            }
+            # Include profile data if available
+            if state.profile:
+                program_data["profile"] = state.profile.to_dict()
+            result[pid] = program_data
+        return JSONResponse(result)
+
+    @app.post("/programs/release")
+    async def release_program(request: Request):
+        """Release a program."""
+        try:
+            payload = await request.json()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="Invalid JSON") from exc
+
+        program_id = payload.get("program_id")
+        if not program_id:
+            raise HTTPException(status_code=400, detail="Missing program_id")
+        program_id = str(program_id)
+
+        released = await ta_router.release_program(program_id)
+        return JSONResponse({"program_id": program_id, "released": released})
+
+    @app.get("/health")
+    async def health_check():
+        """Health check endpoint."""
+        cfg = _get_config()
+        stats = ta_router.get_program_stats()
+        return JSONResponse({
+            "status": "ok",
+            "router_mode": cfg.router_mode,
+            "scheduling_enabled": ta_router.scheduling_enabled,
+            "backends": list(ta_router.backends.keys()),
+            "programs_count": stats["total"],
+            "reasoning_count": stats["reasoning"],
+            "acting_count": stats["acting"],
+            "paused_count": stats["paused"],
+            "per_backend": stats["per_backend"],
+            "profile_enabled": ta_router.profile_enabled,
+        })
+
+    @app.get("/profiles")
+    async def list_profiles():
+        """List all program profiles (timing metrics)."""
+        if not ta_router.profile_enabled:
+            return JSONResponse({"error": "Profiling not enabled. Start with --profile flag."}, status_code=400)
+        result = {}
+        for pid, state in ta_router.programs.items():
+            if state.profile:
+                result[pid] = state.profile.to_dict()
+        return JSONResponse(result)
+
+    @app.get("/profiles/{program_id}")
+    async def get_profile(program_id: str):
+        """Get profile for a specific program."""
+        if not ta_router.profile_enabled:
+            return JSONResponse({"error": "Profiling not enabled. Start with --profile flag."}, status_code=400)
+        state = ta_router.programs.get(program_id)
+        if state is None or state.profile is None:
+            raise HTTPException(status_code=404, detail=f"Profile not found for program: {program_id}")
+        return JSONResponse(state.profile.to_dict())
+
+    @app.get("/v1/models")
+    async def list_models():
+        """List available models (proxy to first backend)."""
+        # Forward to the first available backend
+        if not ta_router.backends:
+            return JSONResponse({"object": "list", "data": []})
+
+        backend_url = next(iter(ta_router.backends.keys()))
+        return await ta_router.proxy_get(backend_url, "/models")
+
+    @app.get("/metrics")
+    async def get_metrics():
+        """Get vLLM metrics from all backends."""
+        cfg = _get_config()
+        paused_counts = ta_router.get_paused_counts_by_backend()
+        return JSONResponse({
+            "metrics_enabled": cfg.metrics_enabled,
+            "metrics_interval": cfg.metrics_interval if cfg.metrics_enabled else None,
+            "backends": {
+                url: backend.to_dict(paused_program_count=paused_counts.get(url, 0))
+                for url, backend in ta_router.backends.items()
+            },
+        })
+
+    # -- Weight sync coordination --
+
+    @app.post("/weight_sync/begin")
+    async def weight_sync_begin():
+        """Notify ThunderAgent that weight sync is starting. Holds new requests."""
+        await ta_router.begin_weight_sync()
+        return JSONResponse({"status": "ok", "weight_sync_active": True})
+
+    @app.post("/weight_sync/end")
+    async def weight_sync_end():
+        """Notify ThunderAgent that weight sync has completed. Releases held requests."""
+        await ta_router.end_weight_sync()
+        return JSONResponse({"status": "ok", "weight_sync_active": False})
+
+
 # =============================================================================
-# FastAPI Application
+# Standalone FastAPI Application
 # =============================================================================
 
 def _create_router() -> MultiBackendRouter:
     """Create router with current config."""
     config = get_config()
     return MultiBackendRouter(
-        config.backends, 
+        config.backends,
         profile_enabled=config.profile_enabled,
         scheduling_enabled=(config.router_mode == "tr"),
         scheduler_interval=config.scheduler_interval,
@@ -28,6 +245,7 @@ def _create_router() -> MultiBackendRouter:
         acting_token_weight=config.acting_token_weight,
         use_acting_token_decay=config.use_acting_token_decay,
     )
+
 
 router = _create_router()
 app = FastAPI(title="ThunderAgent - Program State Tracking Proxy")
@@ -43,180 +261,7 @@ async def shutdown_event():
     await router.stop()
 
 
-def get_program_id(payload: Dict[str, Any]) -> str:
-    """Extract program_id from the request."""
-    if "program_id" in payload:
-        return str(payload["program_id"])
-    extra_body = payload.get("extra_body", {})
-    if isinstance(extra_body, dict) and "program_id" in extra_body:
-        return str(extra_body["program_id"])
-    return "default"
-
-
-@app.post("/v1/chat/completions")
-async def chat_completions(request: Request):
-    """Handle chat completions request."""
-    try:
-        payload = await request.json()
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail="Invalid JSON") from exc
-    # Get or create program state (new programs go to waiting queue)
-    program_id = get_program_id(payload)
-    program_state = router.get_or_create_program(program_id)
-
-    # Profile: record request arrival BEFORE pause check (for accurate tool_call_time)
-    if program_state.profile:
-        program_state.profile.on_request_arrive()
-
-    # Update state: check capacity, may pause and wait (max 20 min, then force resume)
-    await router.update_program_before_request(program_id, program_state, payload)
-    
-    # Profile: record request start AFTER pause (captures pause_time)
-    if program_state.profile:
-        program_state.profile.on_request_start()
-
-    # Resolve backend after any pause/resume to honor migrations.
-    backend = router.get_backend_for_program(program_id)
-
-    # Callback to update state after response
-    async def on_usage(
-        total_tokens: int,
-        prompt_tokens: int | None,
-        completion_tokens: int | None,
-        cached_tokens: int | None,
-    ) -> None:
-        router.update_program_after_request(
-            program_id,
-            program_state,
-            total_tokens,
-            prompt_tokens or 0,
-        )
-        # Profile: record request end with KV cache info
-        if program_state.profile:
-            program_state.profile.on_request_end(
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                cached_tokens=cached_tokens,
-            )
-
-    # Callback for streaming token progress updates (every 20 tokens)
-    def on_token_progress(delta_tokens: int) -> None:
-        router.update_program_tokens_streaming(program_state, delta_tokens)
-
-    # Forward to vLLM (sticky unless rescheduled from the global paused pool)
-    # Pass profile callbacks for token timing
-    return await router.proxy_request(
-        backend, payload,
-        on_usage=on_usage,
-        on_first_token=program_state.profile.on_first_token if program_state.profile else None,
-        on_token=program_state.profile.on_token if program_state.profile else None,
-        on_token_progress=on_token_progress,
-    )
-
-
-@app.get("/programs")
-async def list_programs():
-    """List all programs (includes profile data if profiling enabled)."""
-    result = {}
-    for pid, state in router.programs.items():
-        program_data = {
-            "backend": state.backend_url,
-            "context_len": state.context_len,
-            "total_tokens": state.total_tokens,
-            "step_count": state.step_count,
-            "status": state.status.value,
-            "state": state.state.value,
-        }
-        # Include profile data if available
-        if state.profile:
-            program_data["profile"] = state.profile.to_dict()
-        result[pid] = program_data
-    return JSONResponse(result)
-
-
-@app.post("/programs/release")
-async def release_program(request: Request):
-    """Release a program."""
-    try:
-        payload = await request.json()
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail="Invalid JSON") from exc
-
-    program_id = payload.get("program_id")
-    if not program_id:
-        raise HTTPException(status_code=400, detail="Missing program_id")
-    program_id = str(program_id)
-
-    released = await router.release_program(program_id)
-    return JSONResponse({"program_id": program_id, "released": released})
-
-
-@app.get("/health")
-async def health_check():
-    """Health check endpoint."""
-    config = get_config()
-    stats = router.get_program_stats()
-    return JSONResponse({
-        "status": "ok",
-        "router_mode": config.router_mode,
-        "scheduling_enabled": router.scheduling_enabled,
-        "backends": list(router.backends.keys()),
-        "programs_count": stats["total"],
-        "reasoning_count": stats["reasoning"],
-        "acting_count": stats["acting"],
-        "paused_count": stats["paused"],
-        "per_backend": stats["per_backend"],
-        "profile_enabled": router.profile_enabled,
-    })
-
-
-@app.get("/profiles")
-async def list_profiles():
-    """List all program profiles (timing metrics)."""
-    if not router.profile_enabled:
-        return JSONResponse({"error": "Profiling not enabled. Start with --profile flag."}, status_code=400)
-    result = {}
-    for pid, state in router.programs.items():
-        if state.profile:
-            result[pid] = state.profile.to_dict()
-    return JSONResponse(result)
-
-
-@app.get("/profiles/{program_id}")
-async def get_profile(program_id: str):
-    """Get profile for a specific program."""
-    if not router.profile_enabled:
-        return JSONResponse({"error": "Profiling not enabled. Start with --profile flag."}, status_code=400)
-    state = router.programs.get(program_id)
-    if state is None or state.profile is None:
-        raise HTTPException(status_code=404, detail=f"Profile not found for program: {program_id}")
-    return JSONResponse(state.profile.to_dict())
-
-
-@app.get("/v1/models")
-async def list_models():
-    """List available models (proxy to first backend)."""
-    # Forward to the first available backend
-    if not router.backends:
-        return JSONResponse({"object": "list", "data": []})
-    
-    backend_url = next(iter(router.backends.keys()))
-    return await router.proxy_get(backend_url, "/models")
-
-
-@app.get("/metrics")
-async def get_metrics():
-    """Get vLLM metrics from all backends."""
-    config = get_config()
-    paused_counts = router.get_paused_counts_by_backend()
-    return JSONResponse({
-        "metrics_enabled": config.metrics_enabled,
-        "metrics_interval": config.metrics_interval if config.metrics_enabled else None,
-        "backends": {
-            url: backend.to_dict(paused_program_count=paused_counts.get(url, 0))
-            for url, backend in router.backends.items()
-        },
-    })
+register_routes(app, router)
 
 
 if __name__ == "__main__":

--- a/ThunderAgent/scheduler/router.py
+++ b/ThunderAgent/scheduler/router.py
@@ -116,6 +116,15 @@ class MultiBackendRouter:
         self.char_to_token_ratio: float = 5.0
         self._ratio_initialized: bool = False
 
+        # Weight sync coordination: when active, new data-plane requests block
+        # on _weight_sync_event and the scheduler loop skips ticks. This lets a
+        # trainer pause vLLM backends (e.g. to broadcast new weights) without
+        # racing the ThunderAgent scheduler.
+        self._weight_sync_active: bool = False
+        self._weight_sync_event: asyncio.Event = asyncio.Event()
+        self._weight_sync_event.set()  # Not blocking initially
+        self._weight_sync_watchdog: Optional[asyncio.Task] = None
+
     async def start(self):
         """Start the router."""
         logger.info(f"Started router with {len(self.backends)} backend(s): {list(self.backends.keys())}")
@@ -138,6 +147,15 @@ class MultiBackendRouter:
 
     async def stop(self):
         """Stop the router."""
+        # Stop the weight sync watchdog if running
+        if self._weight_sync_watchdog is not None:
+            self._weight_sync_watchdog.cancel()
+            try:
+                await self._weight_sync_watchdog
+            except asyncio.CancelledError:
+                pass
+            self._weight_sync_watchdog = None
+
         # Stop the scheduler
         if self._scheduler_task:
             self._scheduler_stop = True
@@ -155,6 +173,69 @@ class MultiBackendRouter:
         
         await self.client.aclose()
         logger.info("Router stopped")
+
+    # -------------------------------------------------------------------------
+    # Weight Sync Coordination
+    # -------------------------------------------------------------------------
+
+    @property
+    def weight_sync_active(self) -> bool:
+        return self._weight_sync_active
+
+    async def begin_weight_sync(self, timeout: float = 300.0) -> None:
+        """Enter weight sync mode.
+
+        Effects:
+        1. Sets weight_sync_active flag
+        2. Clears _weight_sync_event so new data-plane requests block
+        3. Scheduler loop will skip ticks while flag is set
+        4. Starts a watchdog timer that auto-exits after ``timeout`` seconds
+
+        Idempotent: a second begin_weight_sync call while already active logs
+        a warning and returns without resetting the watchdog.
+        """
+        if self._weight_sync_active:
+            logger.warning("begin_weight_sync called while already in weight sync mode")
+            return
+        self._weight_sync_active = True
+        self._weight_sync_event.clear()
+        self._weight_sync_watchdog = asyncio.create_task(self._weight_sync_timeout(timeout))
+        logger.info("Weight sync mode ENTERED - holding new requests, suspending scheduler")
+
+    async def end_weight_sync(self) -> None:
+        """Exit weight sync mode and release any held requests.
+
+        Idempotent: end_weight_sync called while not active logs a warning
+        and returns.
+        """
+        if not self._weight_sync_active:
+            logger.warning("end_weight_sync called while not in weight sync mode")
+            return
+        if self._weight_sync_watchdog is not None:
+            self._weight_sync_watchdog.cancel()
+            try:
+                await self._weight_sync_watchdog
+            except asyncio.CancelledError:
+                pass
+            self._weight_sync_watchdog = None
+        self._weight_sync_active = False
+        self._weight_sync_event.set()
+        logger.info("Weight sync mode EXITED - releasing held requests, resuming scheduler")
+
+    async def _weight_sync_timeout(self, timeout: float) -> None:
+        """Watchdog: auto-exit weight sync mode if end_weight_sync is never called."""
+        try:
+            await asyncio.sleep(timeout)
+        except asyncio.CancelledError:
+            return
+        if self._weight_sync_active:
+            logger.error(
+                "Weight sync watchdog fired after %.0fs - auto-exiting weight sync mode to unblock requests",
+                timeout,
+            )
+            self._weight_sync_active = False
+            self._weight_sync_event.set()
+            self._weight_sync_watchdog = None
 
     # -------------------------------------------------------------------------
     # Backend Selection
@@ -295,6 +376,11 @@ class MultiBackendRouter:
         
         Returns: True if can proceed
         """
+        # Block if weight sync is in progress - all data-plane requests wait here
+        if not self._weight_sync_event.is_set():
+            logger.debug(f"Program {program_id} waiting for weight sync to complete")
+            await self._weight_sync_event.wait()
+
         state.step_count += 1
         is_new_program = state.step_count == 1
         
@@ -662,6 +748,8 @@ class MultiBackendRouter:
         while not self._scheduler_stop:
             try:
                 await asyncio.sleep(self._scheduler_interval)
+                if self._weight_sync_active:
+                    continue  # Skip scheduler tick during weight sync
                 await self._scheduled_check()
             except asyncio.CancelledError:
                 break


### PR DESCRIPTION
## Summary

Three small additions to make ThunderAgent embeddable from external FastAPI apps (e.g. an RL training framework that wraps the router with its own integration layer) without forking the package.

### 1. Weight-sync coordination on `MultiBackendRouter`
- New `begin_weight_sync(timeout=300.0)` / `end_weight_sync()` / `weight_sync_active` API.
- `update_program_before_request` now `await`s on an internal `asyncio.Event` so new data-plane requests block while a trainer is broadcasting weights, instead of racing the scheduler.
- The periodic scheduler loop skips ticks while weight sync is active.
- A watchdog auto-exits weight-sync mode after `timeout` seconds, so a crashed trainer never leaves the proxy holding requests forever.
- Two new HTTP routes: `POST /weight_sync/begin`, `POST /weight_sync/end`.

### 2. `register_routes(app, ta_router, config=None)` in `app.py`
- Extracts all HTTP route registration into a reusable function so external FastAPI apps can mount the same route bundle on their own app, with their own router and config.
- The standalone `python -m ThunderAgent` entry point is preserved: the bottom of `app.py` still constructs `router = _create_router()` / `app = FastAPI(...)` and calls `register_routes(app, router)`.

### 3. `get_program_id(payload, headers=None)`
- Adds an `X-Session-ID` header fallback (case-insensitive) after the existing payload checks, so clients that already route by session id can reuse it as the ThunderAgent program id without injecting `program_id` into the payload.

## Motivation

We're integrating ThunderAgent with an external RL training framework. That integration needs (a) a coordination point to hold inference traffic while training broadcasts new weights to the vLLM backends, (b) a way to mount ThunderAgent's routes on an external FastAPI app that owns its own lifespan/config, and (c) a way to identify programs by session id when the client already routes that way. Without these three hooks we have to vendor a copy of the package; with them a plain `pip install` is enough.

## Backwards compatibility

- No behavior change for the standalone `python -m ThunderAgent` server. Existing routes, signatures, and responses are unchanged.
- No new required arguments anywhere — `headers`, `timeout`, and the `register_routes` `config` parameter all have defaults.
- `__init__.py` adds `get_program_id` and `register_routes` to the public exports.

Usage from a library consumer:

```python
from fastapi import FastAPI
from ThunderAgent import MultiBackendRouter, register_routes

app = FastAPI()
router = MultiBackendRouter(["http://localhost:8000"])
register_routes(app, router)
```

## Test plan

- [x] `get_program_id` resolves payload `program_id`, `extra_body.program_id`, `X-Session-ID` / `x-session-id` headers, and the `"default"` fallback in that order.
- [x] `register_routes` registers all 10 routes (8 existing + 2 new `weight_sync/*`) on a fresh FastAPI app.
- [x] `begin_weight_sync` → `end_weight_sync` flips `weight_sync_active` and the internal `_weight_sync_event` correctly; idempotent on double-call.
- [x] Standalone `ThunderAgent.app.app` still constructs (backward compat).
- [ ] End-to-end test under load with an actual vLLM backend (left to reviewer / follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)