### PR TITLE
fix(scheduler): converge _pause_until_safe by reclaiming marked programs' buffer slots

### DIFF
--- a/ThunderAgent/backend/state.py
+++ b/ThunderAgent/backend/state.py
@@ -125,7 +125,18 @@ class BackendState:
     def total_program_tokens(self) -> int:
         """Sum of tokens from all programs on this backend."""
         return sum(p.total_tokens for p in self._programs.values())
-    
+
+    @property
+    def marked_for_pause_count(self) -> int:
+        """Number of active programs already marked for a future pause.
+
+        Used by the thrashing loop to also reclaim each marked program's
+        per-program buffer slot when projecting future capacity, so the
+        loop does not double-count programs it has already scheduled to
+        pause.
+        """
+        return sum(1 for p in self._programs.values() if p.marked_for_pause)
+
     def update_shared_tokens(self) -> None:
         """Update shared_tokens from latest vLLM metrics.
         
@@ -170,8 +181,13 @@ class BackendState:
         where buffer = active_count * BUFFER_PER_PROGRAM
         
         Args:
-            include_future_release: If True, subtract future_paused_tokens from the calculation.
-                                   Use this when checking if more programs need to be paused.
+            include_future_release: If True, subtract the planned release from
+                already-marked REASONING programs. Marked programs will free
+                both their current tokens (``future_paused_tokens``) and their
+                per-program buffer slot once they reach the next pause boundary.
+                Use this when checking if more programs still need to be
+                marked for pause; otherwise the loop double-counts the buffer
+                slots and never converges.
         """
         if not self.cache_config:
             return 0
@@ -179,18 +195,27 @@ class BackendState:
         required = self.active_program_tokens - self.shared_tokens + buffer
         if include_future_release:
             required -= self.future_paused_tokens
+            required -= self.marked_for_pause_count * BUFFER_PER_PROGRAM
         overflow = required - self.cache_config.total_tokens_capacity
         return max(0, overflow)
-    
-    def remaining_capacity(self) -> int:
+
+    def remaining_capacity(self, include_future_release: bool = False) -> int:
         """Return remaining capacity for new programs (can be negative if over capacity).
-        
+
         Uses cached shared_tokens (updated during thrashing check).
+
+        Args:
+            include_future_release: If True, include the planned release from
+                already-marked REASONING programs. This should only be used
+                when deciding whether more programs still need to be marked.
         """
         if not self.cache_config:
             return float('inf')
         buffer = self.active_program_count * BUFFER_PER_PROGRAM
         used = self.active_program_tokens - self.shared_tokens + buffer
+        if include_future_release:
+            used -= self.future_paused_tokens
+            used -= self.marked_for_pause_count * BUFFER_PER_PROGRAM
         return self.cache_config.total_tokens_capacity - used
 
     def remaining_capacity_with_decay(self) -> int:
@@ -267,6 +292,7 @@ class BackendState:
             "total_program_tokens": self.total_program_tokens,
             "paused_program_count": paused_program_count,
             "future_paused_tokens": self.future_paused_tokens,
+            "marked_for_pause_count": self.marked_for_pause_count,
             "shared_tokens": self.shared_tokens,
             "buffer_per_program": BUFFER_PER_PROGRAM,
             "capacity_overflow": self.capacity_overflow(),

--- a/ThunderAgent/scheduler/router.py
+++ b/ThunderAgent/scheduler/router.py
@@ -688,8 +688,13 @@ class MultiBackendRouter:
         Priority: ACTING first (smallest tokens), then REASONING (smallest tokens).
         """
         paused_count = 0
-        
-        while backend.remaining_capacity() < 0:
+
+        # Count already-marked REASONING programs as future release (both their
+        # tokens and their per-program buffer slot) so the loop stops once the
+        # current pause plan is sufficient. Without include_future_release the
+        # buffer slot of each marked program is still counted as in-use, so
+        # the loop keeps marking until every REASONING program is queued.
+        while backend.remaining_capacity(include_future_release=True) < 0:
             # Priority 1: Pause ACTING programs (smallest first)
             acting_programs = self._get_acting_programs_sorted(backend.url, ascending=True)
             if acting_programs:


### PR DESCRIPTION
## Summary

`_pause_until_safe` could keep marking REASONING programs for pause on a small capacity overflow until every REASONING program on the backend was queued — instead of stopping after the minimum needed. The cause: the loop's `remaining_capacity()` check did not subtract the buffer slot of programs already marked, so each mark looked like progress on tokens but no progress on the buffer term, and the loop only converged once `active_program_count` itself dropped.

## Root cause

In `_pause_until_safe`:

```python
while backend.remaining_capacity() < 0:
    ... mark one more REASONING program for pause ...
```

`remaining_capacity()` computes:

```
used = active_program_tokens - shared_tokens + active_program_count * BUFFER_PER_PROGRAM
```

`capacity_overflow(include_future_release=True)` did subtract `future_paused_tokens`, but neither path subtracted `marked_for_pause_count * BUFFER_PER_PROGRAM`. A marked program will free both its tokens and its buffer slot at the next pause boundary, but the in-flight projection only credited the tokens, so on small overflows the loop kept marking.

## Fix

1. New `BackendState.marked_for_pause_count` property.
2. `capacity_overflow(include_future_release=True)` also subtracts `marked_for_pause_count * BUFFER_PER_PROGRAM`.
3. `remaining_capacity()` gains a matching `include_future_release: bool = False` parameter.
4. `_pause_until_safe` switches to `remaining_capacity(include_future_release=True)`.
5. `marked_for_pause_count` exposed in `BackendState.to_dict()` for observability.

Default behavior of `remaining_capacity()` is unchanged for all other call sites.

## Worked example

`total_capacity = 400`, three REASONING programs of 100 tokens each, `shared_tokens = 0`.

| State | `remaining_capacity()` | `remaining_capacity(include_future_release=True)` |
|---|---:|---:|
| Initial (no marks) | `-200` | `-200` |
| After marking 1 program (`future_paused_tokens=100`, `marked_for_pause_count=1`) | `-200` ← loop does not converge | `0` ← loop exits after one mark |

Smoke test output reproducing the above is included in the commit message.

## Backwards compatibility

- `remaining_capacity()` keeps its existing signature: the new parameter defaults to `False`, so all other callers are unchanged.
- `capacity_overflow(include_future_release=True)` now subtracts more from `required`; the maximum overflow it can report stays `>= 0`.

## Test plan

- [x] Unit-level math check on `remaining_capacity(include_future_release=True)` and `capacity_overflow(include_future_release=True)` with a marked program.
- [ ] Integration check under sustained overflow with multiple backends (left to reviewer / follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)