### PR TITLE
fix: retry stale-keepalive ReadErrors on inbound vLLM requests

### DIFF
--- a/ThunderAgent/scheduler/router.py
+++ b/ThunderAgent/scheduler/router.py
@@ -101,9 +101,21 @@ class MultiBackendRouter:
         # Scheduling mode: True = "tr" (capacity scheduling), False = "default" (pure proxy)
         self.scheduling_enabled = scheduling_enabled
 
+        # Keep the keepalive expiry short and well below uvicorn's default
+        # `timeout-keep-alive` (5s) so we close idle connections before the
+        # backend does — otherwise httpx will hand out a pool connection that
+        # the backend has already closed and the first request on it fails
+        # with httpcore.ReadError. AsyncHTTPTransport(retries=1) covers the
+        # connect-side races; the request processor handles the read-side ones.
+        transport_limits = httpx.Limits(
+            max_connections=None,
+            max_keepalive_connections=None,
+            keepalive_expiry=3.0,
+        )
         self.client = httpx.AsyncClient(
             timeout=900.0,
-            limits=httpx.Limits(max_connections=None, max_keepalive_connections=None),
+            limits=transport_limits,
+            transport=httpx.AsyncHTTPTransport(limits=transport_limits, retries=1),
         )
         
         # Scheduler task for periodic capacity check

--- a/ThunderAgent/scheduler/vllm_request_processor.py
+++ b/ThunderAgent/scheduler/vllm_request_processor.py
@@ -6,11 +6,21 @@ Handles HTTP communication with vLLM backends, including:
 - Usage info extraction from responses
 """
 import json
+import logging
 import math
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
 
+import httpcore
 import httpx
 from fastapi.responses import Response, StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+# Number of attempts when a request fails with httpcore/httpx ReadError. These
+# come from stale keepalive connections handed out by the pool after the peer
+# has closed them; one quick retry with a fresh connection is enough in
+# practice. (The httpx transport already retries on ConnectError.)
+_MAX_READ_ERROR_RETRIES = 2
 
 
 def extract_usage_info(
@@ -142,8 +152,21 @@ async def forward_streaming_request(
         elif isinstance(stream_options, dict):
             stream_options.setdefault("include_usage", True)
 
-    resp_cm = client.stream("POST", url, json=payload)
-    resp = await resp_cm.__aenter__()
+    # Retry on ReadError raised before the stream is even opened (stale
+    # keepalive connection closed by the backend between checkout and write).
+    for attempt in range(_MAX_READ_ERROR_RETRIES):
+        try:
+            resp_cm = client.stream("POST", url, json=payload)
+            resp = await resp_cm.__aenter__()
+            break
+        except (httpcore.ReadError, httpx.ReadError) as exc:
+            if attempt < _MAX_READ_ERROR_RETRIES - 1:
+                logger.warning(
+                    "ReadError on stream POST %s (attempt %d/%d): %s",
+                    url, attempt + 1, _MAX_READ_ERROR_RETRIES, exc,
+                )
+                continue
+            raise
     headers = filtered_headers(resp.headers)
     status = resp.status_code
     media_type = resp.headers.get("content-type")
@@ -237,8 +260,20 @@ async def forward_non_streaming_request(
     """
     # Remove program_id before forwarding
     payload = remove_program_id(payload)
-    
-    resp = await client.post(url, json=payload)
+
+    # Retry on ReadError (stale keepalive connections closed by the backend).
+    for attempt in range(_MAX_READ_ERROR_RETRIES):
+        try:
+            resp = await client.post(url, json=payload)
+            break
+        except (httpcore.ReadError, httpx.ReadError) as exc:
+            if attempt < _MAX_READ_ERROR_RETRIES - 1:
+                logger.warning(
+                    "ReadError on POST %s (attempt %d/%d): %s",
+                    url, attempt + 1, _MAX_READ_ERROR_RETRIES, exc,
+                )
+                continue
+            raise
     
     # Extract usage info
     total_tokens: Optional[int] = None
@@ -279,7 +314,18 @@ async def forward_get_request(client: httpx.AsyncClient, url: str) -> Response:
     Returns:
         FastAPI Response with vLLM response content
     """
-    resp = await client.get(url)
+    for attempt in range(_MAX_READ_ERROR_RETRIES):
+        try:
+            resp = await client.get(url)
+            break
+        except (httpcore.ReadError, httpx.ReadError) as exc:
+            if attempt < _MAX_READ_ERROR_RETRIES - 1:
+                logger.warning(
+                    "ReadError on GET %s (attempt %d/%d): %s",
+                    url, attempt + 1, _MAX_READ_ERROR_RETRIES, exc,
+                )
+                continue
+            raise
     return Response(
         content=resp.content,
         status_code=resp.status_code,


### PR DESCRIPTION
## Summary

Under sustained load, requests forwarded to a vLLM backend occasionally fail with `httpcore.ReadError` / `httpx.ReadError` the first time they use a pooled connection. Two small changes make this transparent to the caller:

1. Tighten the router's `httpx.AsyncClient` so it expires keepalive connections before uvicorn does, and use a transport with `retries=1` for connect-side races.
2. Wrap each outbound call in `vllm_request_processor` in a tiny read-side retry loop.

## Root cause

`httpx.AsyncClient` defaults plus uvicorn's default `timeout-keep-alive=5s` produce this race:

1. ThunderAgent forwards a request to vLLM through a pooled keepalive connection.
2. uvicorn closes the idle TCP connection after 5s.
3. Before httpx notices the FIN, it hands out that same connection to the next request.
4. The very first `read` on it raises `httpcore.ReadError` (or `httpx.ReadError` at the httpx layer).
5. The request body has already been written, so the transport's built-in `retries` parameter (which only covers connect-side races) can't help.

## Fix

### `MultiBackendRouter` client construction (`scheduler/router.py`)

```python
transport_limits = httpx.Limits(
    max_connections=None,
    max_keepalive_connections=None,
    keepalive_expiry=3.0,  # below uvicorn's default 5s timeout-keep-alive
)
self.client = httpx.AsyncClient(
    timeout=900.0,
    limits=transport_limits,
    transport=httpx.AsyncHTTPTransport(limits=transport_limits, retries=1),
)
```

- `keepalive_expiry=3.0` makes our pool drop idle connections before the backend does, so the stale-handoff window shrinks dramatically.
- `AsyncHTTPTransport(retries=1)` covers connect-side races (DNS, TCP) that the pool itself can't retry.

### `scheduler/vllm_request_processor.py`

A small read-side retry loop around each of the three outbound primitives:

```python
for attempt in range(_MAX_READ_ERROR_RETRIES):
    try:
        resp = await client.post(url, json=payload)
        break
    except (httpcore.ReadError, httpx.ReadError) as exc:
        if attempt < _MAX_READ_ERROR_RETRIES - 1:
            logger.warning(...)
            continue
        raise
```

`_MAX_READ_ERROR_RETRIES = 2` — one quick retry with a fresh connection is enough in practice. The retry is intentionally **read-side only**:
- The transport's `retries=1` already covers the connect side.
- `ReadError` before any bytes have been read is the only safe case to replay an arbitrary request body — anything later (e.g. mid-stream) we surface to the caller as before.

The streaming, non-streaming, and GET paths all get the same wrapper.

## Backwards compatibility

- No change on the happy path: zero extra latency, zero extra requests.
- No change to public signatures of `forward_streaming_request` / `forward_non_streaming_request` / `forward_get_request`.
- On the bad path, what previously bubbled up as a 5xx from the proxy now succeeds on the second attempt with a fresh connection.

## Test plan

- [x] Router constructs `AsyncHTTPTransport(retries=1)` with `keepalive_expiry=3.0`.
- [x] `forward_non_streaming_request` retries `httpx.ReadError` and succeeds on the second attempt.
- [x] `forward_get_request` retries `httpcore.ReadError` and succeeds on the second attempt.
- [x] When ReadError persists, the wrapper gives up after `_MAX_READ_ERROR_RETRIES` attempts and re-raises.
- [ ] End-to-end soak test with a real vLLM backend and `keepalive` churn (left to reviewer / follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)