### PR TITLE
bug fix: fix the but where app loaded config before CLI parser parsed the input.

### DIFF
--- a/ThunderAgent/__init__.py
+++ b/ThunderAgent/__init__.py
@@ -11,7 +11,7 @@ from .config import Config, get_config, set_config
 from .backend import BackendState
 from .program import ProgramState, ProgramStatus
 from .scheduler import MultiBackendRouter
-from .app import get_program_id, register_routes
+# from .app import get_program_id, register_routes
 
 __all__ = [
     "Config",
@@ -21,8 +21,8 @@ __all__ = [
     "ProgramState",
     "ProgramStatus",
     "MultiBackendRouter",
-    "get_program_id",
-    "register_routes",
+    # "get_program_id",
+    # "register_routes",
 ]
 
 __version__ = "0.2.0"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-bookworm
+
+COPY ./ /opt/ThunderAgent/
+
+RUN pip install --no-build-isolation --no-cache-dir "setuptools>=64" wheel && \
+    pip install --no-build-isolation --no-cache-dir -e /opt/ThunderAgent/


### PR DESCRIPTION
The bug happens when I pass in a custom `--backends http://xxx.xxx.xxx.xxx:30000` from CLI, but it did not take effect. The `thuneragent` still listens to the localhost:8000. Upon investigation, the `register_routes` method in app.py was triggered during import via `__init__.py`. Therefore, as the fix to the bug, I commented out the import from .app since it's not used immediately by the module. 